### PR TITLE
fix(agent): UserPromptSubmit 응답 스펙 준수 / Conform UserPromptSubmit response to official hook spec

### DIFF
--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -119,6 +119,9 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
       });
 
       // Coaching hint injection (D-021)
+      // Response must follow Claude Code UserPromptSubmit hook spec:
+      //   { hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: "..." } }
+      // See https://code.claude.com/docs/en/hooks (UserPromptSubmit).
       let response: Record<string, unknown> = {};
       if (config.agent.coach_mode && (final_score < 65 || hits.some((h) => h.severity >= 3))) {
         const issueLines = hits
@@ -135,7 +138,12 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
           'or proceed while explicitly stating your assumptions.',
           '[end hint]',
         ].join('\n');
-        response = { additionalContext: hint };
+        response = {
+          hookSpecificOutput: {
+            hookEventName: 'UserPromptSubmit',
+            additionalContext: hint,
+          },
+        };
         db.prepare(`UPDATE prompt_usages SET coach_context=? WHERE id=?`).run(hint, usage.id);
       }
 

--- a/packages/agent/test/server.test.ts
+++ b/packages/agent/test/server.test.ts
@@ -77,7 +77,103 @@ describe('agent server', () => {
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    expect(body.additionalContext).toContain('Think-Prompt coaching hint');
+    // Must follow Claude Code UserPromptSubmit hook response spec.
+    // additionalContext belongs inside hookSpecificOutput, not at top level.
+    expect(body.hookSpecificOutput).toBeDefined();
+    expect(body.hookSpecificOutput.hookEventName).toBe('UserPromptSubmit');
+    expect(body.hookSpecificOutput.additionalContext).toContain('Think-Prompt coaching hint');
+    // Regression guard: ensure the old (incorrect) top-level field is not emitted.
+    expect(body.additionalContext).toBeUndefined();
+    await app.close();
+  });
+
+  it('coach_mode omits hint for good prompts', async () => {
+    const app = buildAgentServer({
+      rootOverride: tmp,
+      config: {
+        version: 1,
+        agent: { port: 0, max_prompt_bytes: 262144, coach_mode: true, fail_open: true },
+        dashboard: { port: 47824, open_on_start: false },
+        privacy: {
+          store_original: true,
+          pii_mask: true,
+          retention_days: 90,
+          sync_to_server: false,
+        },
+        llm: {
+          enabled: false,
+          provider: 'anthropic',
+          model: 'claude-haiku-4-5',
+          api_key_env: 'ANTHROPIC_API_KEY',
+          judge_threshold_score: 60,
+          max_monthly_tokens: 500000,
+        },
+        rules: { enabled_set: 'default', custom_disabled: [] },
+        i18n: 'ko',
+      },
+    });
+    const longGoodPrompt = [
+      'Goal: extract the userId field from the response payload of POST /v1/users.',
+      'Context: Node.js 20 TypeScript service in packages/api using Zod schemas.',
+      'Task: add a narrowing helper that returns the userId or throws a typed error.',
+      'Output format: return a TypeScript code block only, no prose.',
+      'Success criteria: the helper compiles under strict mode and has a unit test.',
+    ].join('\n');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/hook/user-prompt-submit',
+      payload: {
+        session_id: 't2-good',
+        cwd: '/tmp',
+        prompt: longGoodPrompt,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // High-quality prompt: no coach hint should be attached.
+    expect(body.hookSpecificOutput).toBeUndefined();
+    expect(body.additionalContext).toBeUndefined();
+    await app.close();
+  });
+
+  it('coach_mode disabled returns empty response even for bad prompts', async () => {
+    const app = buildAgentServer({
+      rootOverride: tmp,
+      config: {
+        version: 1,
+        agent: { port: 0, max_prompt_bytes: 262144, coach_mode: false, fail_open: true },
+        dashboard: { port: 47824, open_on_start: false },
+        privacy: {
+          store_original: true,
+          pii_mask: true,
+          retention_days: 90,
+          sync_to_server: false,
+        },
+        llm: {
+          enabled: false,
+          provider: 'anthropic',
+          model: 'claude-haiku-4-5',
+          api_key_env: 'ANTHROPIC_API_KEY',
+          judge_threshold_score: 60,
+          max_monthly_tokens: 500000,
+        },
+        rules: { enabled_set: 'default', custom_disabled: [] },
+        i18n: 'ko',
+      },
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/hook/user-prompt-submit',
+      payload: {
+        session_id: 't2-off',
+        cwd: '/tmp',
+        prompt: 'fix',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.hookSpecificOutput).toBeUndefined();
+    expect(body.additionalContext).toBeUndefined();
     await app.close();
   });
 


### PR DESCRIPTION
## Summary / 요약

Claude Code `UserPromptSubmit` 훅 응답에서 `additionalContext`를 최상위가 아닌 `hookSpecificOutput` 안에 중첩해 반환하도록 수정. 공식 스펙 위반으로 인해 **coach mode 힌트가 실제 Claude 컨텍스트에 주입되지 못하던 문제**를 해결.

Fixes Claude Code `UserPromptSubmit` hook response format to correctly nest `additionalContext` inside `hookSpecificOutput` per the official hook spec. The previous flat shape meant **coach-mode hints were silently dropped** by Claude Code.

- Before / 기존: `{ additionalContext: "..." }`
- After / 수정: `{ hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: "..." } }`

Spec reference / 스펙 출처: https://code.claude.com/docs/en/hooks (UserPromptSubmit)

## Changes / 변경

- `packages/agent/src/server.ts` — wrap response in `hookSpecificOutput`, add spec-link comment
- `packages/agent/test/server.test.ts` — update assertion to nested shape, add regression guard (top-level `additionalContext` must be `undefined`), add 2 negative cases (coach off, high-quality prompt)

## Review / 리뷰

`typescript-reviewer` 에이전트 자동 리뷰 결과 — **APPROVE**, CRITICAL/HIGH 이슈 없음. 2건 MEDIUM 관찰:

1. `response` 변수가 `Record<string, unknown>` 로 느슨하게 타이핑됨 — 별도 `UserPromptSubmitResponse` 타입 도입 권장 (follow-up).
2. `hookEventName: 'UserPromptSubmit'` 이 bare string — 모듈 레벨 `as const` 상수화 권장 (follow-up).

두 건 모두 이번 PR 범위 밖 개선 제안으로, 머지 후 별도 PR로 처리 권장.

`typescript-reviewer` agent: **APPROVE**. No CRITICAL/HIGH findings. Two MEDIUM observations about loose typing of the response variable and string-literal `hookEventName` are deferred to follow-up PRs.

## Test plan / 테스트 계획

- [x] `packages/agent` 테스트 6/6 통과 (신규 2 케이스 포함)
- [x] `pnpm typecheck` clean (6 packages)
- [x] `pnpm exec biome check` 변경 파일 clean
- [ ] **Phase 2 O-010 실측 (유저 직접 수행 필요)** — `think-prompt install` 후 Claude Code 세션에서 coach hint가 실제 Claude 답변에 반영되는지 검증 → `docs/99-observation-log.md` 에 결과 기록

Known unrelated failures on `main` / 기존 main 실패(이 PR 무관):
- `dashboard > renders prompt detail`
- `dashboard > records feedback via POST /prompts/:id/feedback`
- `worker > parses session transcript and recomputes usage scores`

위 3건은 `outcomes` 테이블 마이그레이션 누락 이슈로 `origin/main`에서 재현됨. 본 PR 범위 밖.

## Impact / 영향

- `99-observation-log.md` O-010 (coaching hint가 Claude 답변에 영향 주는지) — 이 수정이 선행돼야 의미있는 실측 가능.
- `docs/06-coaching-ux.md` §2 인라인 코칭 동작이 비로소 스펙대로 작동.

Refs: D-021 (coaching hint injection)