### PR TITLE
feat: 브라우저 확장 v0.3.x + 파이프라인 동기화 / Bulk sync: browser extension v0.3.x + pipeline updates

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,7 +1,8 @@
 # Think-Prompt v0.1.0 — 빌드 리포트
 
-**세션 날짜:** 2026-04-20
-**상태:** 전 기능 구현 완료 · CI 전 단계 통과 · 스모크 테스트 통과
+**최초 빌드:** 2026-04-20
+**마지막 업데이트:** 2026-04-22 (browser-extension v0.3.0 + autostart 스캐폴딩 + B1/B2/B3 안정화)
+**상태:** 전 기능 구현 완료 · CI 전 단계 통과 · 스모크 테스트 통과 · 운영 안정화 진행 중
 
 ---
 
@@ -13,50 +14,49 @@
 
 ---
 
-## 1. 구현된 패키지 (6개 · monorepo)
+## 1. 구현된 패키지 (7개 · monorepo)
 
 | 패키지 | 역할 | 빌드 산출물 |
 |---|---|---|
-| `@think-prompt/core` | SQLite DB · 설정 · 로거 · PII · 스코어러 · 큐 · 트랜스크립트 파서 · Anthropic 클라이언트 | `dist/index.js` (24 KB), `dist/db.js`, `dist/transcript/parser.js` |
-| `@think-prompt/rules` | 안티패턴 룰 R001~R012 + 카탈로그 | `dist/index.js` (9.9 KB) |
-| `@think-prompt/agent` | Fastify HTTP 훅 수신기(6개 엔드포인트) | `dist/index.js` (8.5 KB) bin: `think-prompt-agent` |
-| `@think-prompt/worker` | 큐 소비 데몬 — 트랜스크립트 파싱 · LLM 심판 · 리라이터 | `dist/index.js` (11.8 KB) bin: `think-prompt-worker` |
-| `@think-prompt/dashboard` | 로컬 웹 UI (Fastify + Tailwind CDN + htmx) | `dist/index.js` (21.4 KB) bin: `think-prompt-dashboard` |
-| `@think-prompt/cli` | 18개 서브커맨드 (install/start/doctor/list/rewrite …) | `dist/index.js` (28.2 KB) bin: `think-prompt` |
+| `@think-prompt/core` | SQLite DB · 설정 · 로거 · PII · 스코어러 · 큐 · 트랜스크립트 파서 · Anthropic 클라이언트 | `dist/index.js`, `dist/db.js`, `dist/transcript/parser.js` |
+| `@think-prompt/rules` | 안티패턴 룰 R001~R013 + 카탈로그 | `dist/index.js` |
+| `@think-prompt/agent` | Fastify HTTP 훅 수신기(6 hook routes + `/v1/ingest/web`) | `dist/index.js` bin: `think-prompt-agent` |
+| `@think-prompt/worker` | 큐 소비 데몬 — 트랜스크립트 파싱 · LLM 심판 · 리라이터 | `dist/index.js` bin: `think-prompt-worker` |
+| `@think-prompt/dashboard` | 로컬 웹 UI (Fastify + eta + Tailwind CDN + htmx) | `dist/index.js` bin: `think-prompt-dashboard` |
+| `@think-prompt/cli` | 19개 서브커맨드 (install/start/doctor/list/rewrite/autostart …) | `dist/index.js` (~35 KB) bin: `think-prompt` |
+| `@think-prompt/browser-extension` | Chrome MV3 — ChatGPT/Claude/Gemini/Perplexity/Genspark 어댑터 | `dist/extension/` (esbuild) |
 
-**구조:** `pnpm` workspace · TypeScript strict + exactOptionalPropertyTypes · ESM.
+**구조:** `pnpm` workspace · TypeScript strict + exactOptionalPropertyTypes · ESM. **DB 스키마:** v3.
 
 ---
 
-## 2. CI 상태 (2026-04-20 16:52 KST)
+## 2. CI 상태 (2026-04-22 갱신)
 
 ```
 === typecheck ===
-packages/core typecheck: Done
-packages/rules typecheck: Done
-packages/agent typecheck: Done
-packages/worker typecheck: Done
-packages/dashboard typecheck: Done
-packages/cli typecheck: Done
+7/7 packages: Done
 
 === test ===
- ✓ @think-prompt/core   test/parser.test.ts    (7 tests)
- ✓ @think-prompt/core   test/scorer.test.ts    (9 tests)
- ✓ @think-prompt/core   test/pii.test.ts       (7 tests)
- ✓ @think-prompt/core   test/db.test.ts        (4 tests)
- ✓ @think-prompt/rules  test/rules.test.ts     (11 tests)
- ✓ @think-prompt/agent  test/server.test.ts    (4 tests)
- ✓ @think-prompt/worker test/jobs.test.ts      (3 tests)
- ✓ @think-prompt/dashboard test/server.test.ts (3 tests)
- ✓ @think-prompt/cli    test/settings-merge.test.ts (5 tests)
- Test Files  9 passed | Tests  53 passed
+ ✓ 14 test files | 128 tests passed | 0 failed
+   - @think-prompt/core            (parser·scorer·pii·db)
+   - @think-prompt/rules           (rules)
+   - @think-prompt/agent           (server — 8 tests)
+   - @think-prompt/worker          (jobs — 4 tests, +1 새 케이스)
+   - @think-prompt/dashboard       (server — 4 tests)
+   - @think-prompt/cli             (settings-merge)
+   - @think-prompt/browser-extension (chatgpt-adapter + pii)
 
 === lint (biome) ===
-Found 0 errors · 52 warnings (모두 스타일 경고)
+Found 0 errors · 56 warnings (대부분 `any` 사용 — I2 cleanup 진행 중)
 
 === build ===
-6/6 packages built successfully
+7/7 packages built successfully
 ```
+
+**최근 안정화 (2026-04-22):**
+- B1: `jsdom`이 워크스페이스 루트 devDeps에 누락돼 `pnpm test`가 무너졌던 것 수정 (`pnpm add -Dw jsdom @types/jsdom`)
+- B2: `parse_subagent_transcript` job이 transcript 미존재 시 4회 retry 후 DLQ로 흘러가던 흐름을 1회 시도 후 `done`+drop로 변경. DLQ 노이즈 28건 → 0건 예상
+- B3: agent `subagent-stop`이 `subagent-start` 누락 케이스에서 SQLITE_CONSTRAINT_FOREIGNKEY로 실패하던 것 수정 — `upsertSession` 방어 호출 추가
 
 ---
 
@@ -204,7 +204,14 @@ HTML 정상 렌더, Tailwind CDN 로드
 ### 6.5 아직 안 한 것
 - GitHub 리포 생성 · 첫 푸시 (유저가 리모트 생성 후 `git remote add` + push)
 - npm publish (v0.1.0 릴리스는 유저 결정 후)
-- M0 실측 (유저 작업)
+- M0 실측 (유저 작업) — 현재 prompt_usages 5+ 캡처되며 O-001/003/005/007은 99-observation-log.md에 resolved 기록됨. 나머지 O-002/004/006/008/009/010은 사용자 시나리오 검증 필요
+- I1: CLI 패키지 테스트 커버리지 (현재 17 src · 2 test — autostart 16건 + settings-merge 5건) 상향 — install/doctor/list/show/rewrite 등 미테스트 영역 추가
+- I2: 남은 lint warnings 40건 (`any` → `unknown`+narrow) 정리 — 핵심 16건은 2026-04-22 처리 완료, 비핵심 40건 (logger / llm / settings-merge / browser-extension internal 등) 후속
+
+### 6.6 운영 자동화 (2026-04-22 추가)
+- macOS launchd LaunchAgent 3개로 agent/worker/dashboard 자동 기동 적용 — `~/Library/LaunchAgents/com.thinkprompt.{agent,worker,dashboard}.plist`
+- `KeepAlive: { SuccessfulExit: false }` — 충돌 시만 부활, `think-prompt stop` 존중
+- `think-prompt autostart status`로 점검 가능 (enable은 [WIP — policy TODO])
 
 ---
 
@@ -240,15 +247,16 @@ think-prompt/
 │   ├── conversation-log.md
 │   └── proposal-draft.md
 └── packages/
-    ├── core/   (3 migrations · 7 src · 4 test)
-    ├── rules/  (types · keywords · 12 rules · registry · test)
-    ├── agent/  (server with 6 routes · index · test)
-    ├── worker/ (jobs.ts with 5 handlers · index · test)
-    ├── dashboard/ (server with 7 routes · html helper · test)
-    └── cli/    (18 subcommands · daemon lifecycle · settings merge · test)
+    ├── core/   (3 migrations · 14 src · 5 test)
+    ├── rules/  (types · keywords · 13 rules · registry · 2 test)
+    ├── agent/  (server with 6 hook routes + /v1/ingest/web · 1 test)
+    ├── worker/ (jobs.ts with 5 handlers · index · 1 test)
+    ├── dashboard/ (server with 7 routes · html helper · 1 test)
+    ├── cli/    (19 subcommands · daemon lifecycle · settings merge · autostart · 1 test)
+    └── browser-extension/ (MV3 · 5 site adapters · background queue · pii · 2 test)
 ```
 
-총 파일 수: 약 **75개** (설계 문서 12 + 소스/설정 63).
+총 파일 수: **80+** (설계 문서 13 + 소스/설정 70+).
 
 ---
 
@@ -269,4 +277,5 @@ think-prompt reprocess --all|--session <id>
 think-prompt export --since 30d --out file.json
 think-prompt open
 think-prompt wipe --yes
+think-prompt autostart status            # launchd / systemd unit 점검
 ```

--- a/docs/99-observation-log.md
+++ b/docs/99-observation-log.md
@@ -15,13 +15,13 @@
 
 | # | 질문 | 관련 문서 §  | 상태 |
 |---|---|---|---|
-| O-001 | `UserPromptSubmit` payload의 정확한 키 이름(예: `prompt`)과 슬래시 커맨드가 원문/확장본 중 무엇으로 들어오는지 | 01-hook-design §1, 04-transcript-parser §7 | pending |
+| O-001 | `UserPromptSubmit` payload의 정확한 키 이름(예: `prompt`)과 슬래시 커맨드가 원문/확장본 중 무엇으로 들어오는지 | 01-hook-design §1, 04-transcript-parser §7 | **resolved (2026-04-22)** — 키 = `prompt` (string). 슬래시 커맨드 전개 형태는 별도 검증 필요 |
 | O-002 | `SubagentStart/Stop` payload에 prompt 필드 존재 여부 | 01-hook-design §1 | pending |
-| O-003 | `transcript_path` 실제 경로 패턴 | 04-transcript-parser §1, §7 | pending |
-| O-004 | 트랜스크립트 JSONL 이벤트 키 이름 (`type`, `role`, `content`, `message`) | 04-transcript-parser §2 | pending |
-| O-005 | 서브에이전트 호출이 세션 트랜스크립트에 인라인 vs 별도 파일 | 04-transcript-parser §7 | pending |
+| O-003 | `transcript_path` 실제 경로 패턴 | 04-transcript-parser §1, §7 | **resolved (2026-04-22)** — `~/.claude/projects/<slugified-cwd>/<session_id>.jsonl` |
+| O-004 | 트랜스크립트 JSONL 이벤트 키 이름 (`type`, `role`, `content`, `message`) | 04-transcript-parser §2 | partial (parser는 가정대로 동작 중, 직접 JSONL inspection은 별도) |
+| O-005 | 서브에이전트 호출이 세션 트랜스크립트에 인라인 vs 별도 파일 | 04-transcript-parser §7 | **resolved (2026-04-22)** — 별도 파일. `agent_transcript_path`로 SubagentStop payload에 전달 |
 | O-006 | `/compact` 후 session_id 유지 여부 | 01-hook-design §1 | pending |
-| O-007 | HTTP `type` 훅이 `UserPromptSubmit` 포함 모든 이벤트에서 동작하는지 | 01-hook-design §9 | pending |
+| O-007 | HTTP `type` 훅이 `UserPromptSubmit` 포함 모든 이벤트에서 동작하는지 | 01-hook-design §9 | **resolved (2026-04-22)** — 6개 hook 모두 :47823으로 정상 도달 |
 | O-008 | `resume` 시 새 `SessionStart` 발화 여부 | 01-hook-design §1 | pending |
 | O-009 | 훅 timeout 초과 시 Claude Code 동작 (대기 vs 무시) | 01-hook-design §8 | pending |
 | O-010 | `additionalContext`가 실제 Claude 답변에 미치는 영향 강도 | 06-coaching-ux §2 | pending |
@@ -31,3 +31,20 @@
 ## 관찰 기록
 
 *(여기 아래에 날짜순으로 append)*
+
+### 2026-04-22 · 운영 로그 기반 일괄 관찰 (5+건 캡처 확인)
+
+**Source:** `~/.think-prompt/{agent,worker}.log`, `prompts.db` (5+ rows in `prompt_usages`), `~/Library/LaunchAgents/com.thinkprompt.*.plist` (launchd autostart 동작 중)
+
+**Observed:**
+- **O-001 키 이름:** UserPromptSubmit payload는 `body.prompt: string`. 우리 zod 스키마 `UserPromptSubmitPayload`와 일치. agent.ts:69 `p.prompt`로 직접 접근, 5+ 캡처에서 score / tier / hits 모두 비어있지 않음 (예: score=85, tier=good, hits=2).
+- **O-003 transcript_path 패턴:** `/Users/<user>/.claude/projects/<slugified-cwd>/<session_id>.jsonl`. 슬러그화 규칙 = 슬래시·도트를 하이픈으로, 선두 슬래시도 하이픈. 예: cwd `/Users/must-hoyoung/Documents/claude-management/think-prompt` → 디렉토리 `-Users-must-hoyoung-Documents-claude-management-think-prompt`. worker DLQ 기록의 `agent_transcript_path` payload에서도 동일 패턴 관찰.
+- **O-005 서브에이전트 트랜스크립트:** SubagentStop payload에 별도 `agent_transcript_path` 필드 포함. 메인 세션 트랜스크립트에 인라인되지 않음 → 04-transcript-parser §7 가정 확정.
+- **O-007 훅 라우팅:** 6개 hook (UserPromptSubmit / SessionStart / SubagentStart / SubagentStop / Stop / PostToolUse) 모두 `:47823`으로 도달, agent.log에 INFO 레벨 기록. fail-open 코드 경로(`config.agent.fail_open`)는 unhandled error 발생 시에만 `{}` 반환.
+
+**Doc impact:**
+- 04-transcript-parser §1: 경로 패턴 명시 권장
+- 04-transcript-parser §7: 서브에이전트 별도 파일 확정
+- 01-hook-design §9: HTTP type 훅 6종 라우팅 정상 동작 확정
+
+**미해결:** O-002, O-004(가정대로 작동 중이지만 직접 JSONL 키 검증 별도 필요), O-006, O-008, O-009, O-010 — 모두 사용자가 특정 시나리오를 만들어야 검증 가능 (compact / resume / 인위적 timeout / Claude 답변 비교 실험).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@types/jsdom": "^28.0.1",
     "@types/node": "^22.10.0",
+    "jsdom": "^25.0.1",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -189,6 +189,10 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
   fastify.post('/v1/hook/subagent-stop', async (req) => {
     try {
       const p = SubagentStopPayload.parse(req.body);
+      // Defensive: subagent-start may have been missed (different daemon
+      // instance, restart, or Claude Code skipping the start hook). Ensure
+      // the parent session row exists before the FK-bound subagents insert.
+      upsertSession(db, { id: p.session_id, cwd: p.cwd ?? '/' });
       upsertSubagent(db, {
         session_id: p.session_id,
         agent_type: p.agent_type,
@@ -257,8 +261,20 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
 
   // /v1/ingest/web — prompts captured by the browser extension.
   // See docs/09-browser-extension-design.md §7.
-  fastify.post('/v1/ingest/web', async (req) => {
+  //
+  // Soft-auth via the `X-Think-Prompt-Ext` header: the agent binds to 127.0.0.1
+  // so network attackers are already blocked, but unrelated local processes
+  // (or a drive-by fetch from an unrelated browser tab) should not be able to
+  // pollute the local store. The browser extension sets this header on every
+  // call; anything missing it gets a 403.
+  fastify.post('/v1/ingest/web', async (req, reply) => {
     const t0 = Date.now();
+    const extHeader = req.headers['x-think-prompt-ext'];
+    if (extHeader !== '1') {
+      logger.warn({ hasHeader: extHeader != null }, 'web-ingest rejected — missing ext header');
+      reply.code(403);
+      return { ok: false, error: 'missing X-Think-Prompt-Ext header' };
+    }
     try {
       const p = WebIngestPayload.parse(req.body);
       const sessionId = `${p.source}:${p.browser_session_id}`;

--- a/packages/agent/test/server.test.ts
+++ b/packages/agent/test/server.test.ts
@@ -198,6 +198,7 @@ describe('agent server', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/v1/ingest/web',
+      headers: { 'x-think-prompt-ext': '1' },
       payload: {
         source: 'chatgpt',
         browser_session_id: 'c-abc-123',
@@ -218,6 +219,7 @@ describe('agent server', () => {
     await app.inject({
       method: 'POST',
       url: '/v1/ingest/web',
+      headers: { 'x-think-prompt-ext': '1' },
       payload: {
         source: 'claude-ai',
         browser_session_id: 'c-xyz-777',
@@ -231,5 +233,22 @@ describe('agent server', () => {
       | undefined;
     expect(row?.source).toBe('claude-ai');
     db.close();
+  });
+
+  it('/v1/ingest/web rejects requests missing the X-Think-Prompt-Ext header', async () => {
+    const app = buildAgentServer({ rootOverride: tmp });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/ingest/web',
+      payload: {
+        source: 'chatgpt',
+        browser_session_id: 'c-nope',
+        prompt_text: 'drive-by',
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    const body = res.json();
+    expect(body.ok).toBe(false);
+    await app.close();
   });
 });

--- a/packages/browser-extension/manifest.json
+++ b/packages/browser-extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Think-Prompt for Web",
   "version": "0.3.0",
   "description": "Local-first prompt coach for ChatGPT, Claude.ai, Gemini, Perplexity, and Genspark. Your prompts stay on your machine.",
-  "permissions": ["storage"],
+  "permissions": ["storage", "alarms"],
   "host_permissions": [
     "https://chatgpt.com/*",
     "https://chat.openai.com/*",

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -6,12 +6,15 @@
   "private": true,
   "scripts": {
     "build": "node build.mjs",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@think-prompt/rules": "workspace:*"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@types/chrome": "^0.0.290",
     "esbuild": "^0.24.0",
     "jsdom": "^25.0.1",

--- a/packages/browser-extension/playwright.config.ts
+++ b/packages/browser-extension/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright config for the browser extension.
+ *
+ * The E2E suite loads the built `dist/` directory as an unpacked extension
+ * via `chromium.launchPersistentContext`. Run with:
+ *
+ *   pnpm -F @think-prompt/browser-extension build
+ *   pnpm -F @think-prompt/browser-extension e2e
+ *
+ * The chromium binary is NOT installed on `pnpm install` — call
+ * `pnpm exec playwright install chromium` once before the first run.
+ */
+export default defineConfig({
+  testDir: './test/e2e',
+  timeout: 30_000,
+  fullyParallel: false,
+  reporter: [['list']],
+  use: {
+    headless: true,
+  },
+});

--- a/packages/browser-extension/src/background/agent-client.ts
+++ b/packages/browser-extension/src/background/agent-client.ts
@@ -1,17 +1,26 @@
 /**
  * Think-Prompt local agent client. Localhost only.
+ *
+ * All requests carry `X-Think-Prompt-Ext: 1` so the agent can distinguish
+ * calls originating from this extension versus incidental cross-origin
+ * traffic from other local processes. See agent/src/server.ts and
+ * docs/09-browser-extension-design.md §7.3.
  */
 
 import type { IngestResult } from '../shared/types.js';
 import type { QueueRow } from './queue.js';
 
 const AGENT_BASE = 'http://127.0.0.1:47823';
+const EXT_HEADER = { 'x-think-prompt-ext': '1' } as const;
 
 export async function agentReachable(timeoutMs = 500): Promise<boolean> {
   try {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
-    const res = await fetch(`${AGENT_BASE}/health`, { signal: ctrl.signal });
+    const res = await fetch(`${AGENT_BASE}/health`, {
+      signal: ctrl.signal,
+      headers: EXT_HEADER,
+    });
     clearTimeout(timer);
     return res.ok;
   } catch {
@@ -30,7 +39,7 @@ export async function sendIngest(row: QueueRow): Promise<IngestResult> {
   };
   const res = await fetch(`${AGENT_BASE}/v1/ingest/web`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...EXT_HEADER },
     body: JSON.stringify(body),
   });
   if (!res.ok) {

--- a/packages/browser-extension/src/background/index.ts
+++ b/packages/browser-extension/src/background/index.ts
@@ -3,11 +3,61 @@
  *
  * Receives captured prompts from content scripts, masks PII on-device,
  * queues to IndexedDB, and syncs to the local Think-Prompt agent.
+ *
+ * Additional responsibilities (v0.3.x):
+ *  - Honor the per-site on/off toggle stored in chrome.storage.local
+ *    (key: SITE_TOGGLE_STORAGE_KEY). Disabled sites bypass capture entirely.
+ *  - Surface the latest quality tier/score as an action-badge so the user
+ *    sees feedback without opening the popup.
+ *  - Use chrome.alarms (not setInterval) to drain the queue — MV3 service
+ *    workers die after ~30s idle and setInterval stops firing.
  */
 import { maskPii } from '../shared/pii.js';
 import type { CapturedPrompt, IngestResult, Message } from '../shared/types.js';
 import { agentReachable, sendIngest } from './agent-client.js';
 import { enqueue, markError, markSynced, pendingRows, stats } from './queue.js';
+import { installToggleSubscription, isSiteEnabled } from './site-toggle.js';
+
+const DRAIN_ALARM = 'think-prompt-drain';
+
+installToggleSubscription();
+
+// --- Badge feedback -----------------------------------------------------
+
+type Tier = 'good' | 'ok' | 'weak' | 'bad';
+const TIER_COLORS: Record<Tier, string> = {
+  good: '#22c55e',
+  ok: '#3b82f6',
+  weak: '#f59e0b',
+  bad: '#ef4444',
+};
+
+async function setBadge(tabId: number | undefined, text: string, color: string): Promise<void> {
+  if (tabId == null) return;
+  try {
+    await chrome.action.setBadgeText({ tabId, text });
+    await chrome.action.setBadgeBackgroundColor({ tabId, color });
+  } catch {
+    // action API not available in some MV3 contexts (e.g. under test).
+  }
+}
+
+async function markTabWatching(tabId: number | undefined): Promise<void> {
+  // Small green dot confirms the content script is live on this tab.
+  await setBadge(tabId, '●', TIER_COLORS.good);
+}
+
+async function showScoreBadge(
+  tabId: number | undefined,
+  score: number | undefined,
+  tier: Tier | undefined
+): Promise<void> {
+  if (score == null || tier == null) return;
+  const text = score >= 100 ? '99+' : String(Math.max(0, Math.round(score)));
+  await setBadge(tabId, text, TIER_COLORS[tier]);
+}
+
+// --- Pipeline -----------------------------------------------------------
 
 async function sha256Hex(input: string): Promise<string> {
   const bytes = new TextEncoder().encode(input);
@@ -16,7 +66,11 @@ async function sha256Hex(input: string): Promise<string> {
   return arr.map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
-async function handlePrompt(p: CapturedPrompt): Promise<IngestResult> {
+async function handlePrompt(p: CapturedPrompt, tabId?: number): Promise<IngestResult> {
+  if (!(await isSiteEnabled(p.source))) {
+    return { ok: true, disabled: true };
+  }
+
   const { masked, hits } = maskPii(p.prompt_text);
   const hash = await sha256Hex(p.prompt_text);
   const id = `${hash.slice(0, 8)}-${Date.now()}`;
@@ -39,6 +93,7 @@ async function handlePrompt(p: CapturedPrompt): Promise<IngestResult> {
   try {
     const result = await sendIngest(row);
     await markSynced(id);
+    await showScoreBadge(tabId, result.score, result.tier);
     return result;
   } catch (err) {
     await markError(id, (err as Error).message);
@@ -62,29 +117,57 @@ async function drainPending(): Promise<number> {
   return ok;
 }
 
-chrome.runtime.onMessage.addListener((msg: Message, _sender, sendResponse) => {
-  if (msg.kind === 'prompt') {
-    handlePrompt(msg.payload)
-      .then((r) => sendResponse(r))
-      .catch((err) => sendResponse({ ok: false, error: (err as Error).message }));
-    return true; // async response
-  }
-  return false;
-});
+// --- Message routing ----------------------------------------------------
 
-chrome.runtime.onMessage.addListener((msg: any, _sender, sendResponse) => {
-  if (msg?.kind === 'stats') {
+chrome.runtime.onMessage.addListener((msg: Message, sender, sendResponse) => {
+  const tabId = sender.tab?.id;
+
+  if (msg.kind === 'prompt') {
+    handlePrompt(msg.payload, tabId)
+      .then((r) => sendResponse(r))
+      .catch((err) =>
+        sendResponse({ ok: false, error: (err as Error).message } satisfies IngestResult)
+      );
+    return true;
+  }
+
+  if (msg.kind === 'content-loaded') {
+    isSiteEnabled(msg.source).then((enabled) => {
+      if (enabled) {
+        void markTabWatching(tabId);
+      } else {
+        void setBadge(tabId, '', '#999999');
+      }
+      sendResponse({ ok: true, enabled });
+    });
+    return true;
+  }
+
+  if (msg.kind === 'stats') {
     stats().then(sendResponse);
     return true;
   }
-  if (msg?.kind === 'sync-now') {
+
+  if (msg.kind === 'sync-now') {
     drainPending().then((n) => sendResponse({ synced: n }));
     return true;
   }
+
   return false;
 });
 
-// Periodic drain — best-effort; SW will be killed when idle.
-setInterval(() => {
-  drainPending().catch(() => {});
-}, 60 * 1000);
+// --- Periodic drain (MV3-safe) -----------------------------------------
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.alarms.create(DRAIN_ALARM, { periodInMinutes: 1 });
+});
+chrome.runtime.onStartup.addListener(() => {
+  chrome.alarms.create(DRAIN_ALARM, { periodInMinutes: 1 });
+});
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === DRAIN_ALARM) {
+    drainPending().catch(() => {
+      // swallowed — SW will be re-armed on the next alarm
+    });
+  }
+});

--- a/packages/browser-extension/src/background/queue.ts
+++ b/packages/browser-extension/src/background/queue.ts
@@ -4,11 +4,18 @@
  * Service workers can be killed at any time. We persist every captured
  * prompt to IndexedDB as soon as it arrives, then attempt sync. The local
  * agent accepting the row flips `synced` to true.
+ *
+ * After MAX_ATTEMPTS consecutive sync failures we mark the row `poisoned`
+ * so `pendingRows()` stops returning it — the popup surfaces the count
+ * and the user can trigger a manual retry from Options (future work).
  */
 
 const DB_NAME = 'think-prompt-ext';
 const STORE = 'ingest';
 const DB_VERSION = 1;
+
+/** Upper bound on sync retries before a row is parked as poisoned. */
+export const MAX_ATTEMPTS = 5;
 
 export interface QueueRow {
   id: string; // prompt_hash + timestamp
@@ -21,6 +28,8 @@ export interface QueueRow {
   synced: boolean;
   attempts: number;
   last_error?: string;
+  /** Marked `true` once attempts >= MAX_ATTEMPTS; excluded from pendingRows(). */
+  poisoned?: boolean;
 }
 
 function open(): Promise<IDBDatabase> {
@@ -80,6 +89,9 @@ export async function markError(id: string, err: string): Promise<void> {
       if (row) {
         row.last_error = err;
         row.attempts = (row.attempts ?? 0) + 1;
+        if (row.attempts >= MAX_ATTEMPTS && !row.synced) {
+          row.poisoned = true;
+        }
         store.put(row);
       }
     };
@@ -87,6 +99,17 @@ export async function markError(id: string, err: string): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+}
+
+/**
+ * Predicate: is this row still eligible for retry?
+ * Exposed so unit tests can exercise the retry/poisoning boundary without
+ * booting IndexedDB.
+ */
+export function isRowRetriable(row: QueueRow): boolean {
+  if (row.synced) return false;
+  if (row.poisoned) return false;
+  return (row.attempts ?? 0) < MAX_ATTEMPTS;
 }
 
 export async function pendingRows(limit = 50): Promise<QueueRow[]> {
@@ -98,7 +121,7 @@ export async function pendingRows(limit = 50): Promise<QueueRow[]> {
       .index('synced')
       .getAll(IDBKeyRange.only(false as any));
     req.onsuccess = () => {
-      const rows = (req.result as QueueRow[]).slice(0, limit);
+      const rows = (req.result as QueueRow[]).filter(isRowRetriable).slice(0, limit);
       resolve(rows);
     };
     req.onerror = () => reject(req.error);
@@ -106,7 +129,12 @@ export async function pendingRows(limit = 50): Promise<QueueRow[]> {
   });
 }
 
-export async function stats(): Promise<{ total: number; synced: number; pending: number }> {
+export async function stats(): Promise<{
+  total: number;
+  synced: number;
+  pending: number;
+  poisoned: number;
+}> {
   const db = await open();
   return await new Promise((resolve, reject) => {
     const tx = db.transaction(STORE, 'readonly');
@@ -114,7 +142,9 @@ export async function stats(): Promise<{ total: number; synced: number; pending:
     req.onsuccess = () => {
       const rows = req.result as QueueRow[];
       const synced = rows.filter((r) => r.synced).length;
-      resolve({ total: rows.length, synced, pending: rows.length - synced });
+      const poisoned = rows.filter((r) => r.poisoned).length;
+      const pending = rows.length - synced - poisoned;
+      resolve({ total: rows.length, synced, pending, poisoned });
     };
     req.onerror = () => reject(req.error);
     tx.oncomplete = () => db.close();

--- a/packages/browser-extension/src/background/site-toggle.ts
+++ b/packages/browser-extension/src/background/site-toggle.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-site on/off toggle backed by chrome.storage.local.
+ *
+ * The Options page writes `SITE_TOGGLE_STORAGE_KEY` as
+ * `Record<SiteId, boolean>`. Missing entries mean "enabled" (opt-out model).
+ *
+ * Exposed as a standalone module so it is trivially unit-testable without
+ * booting the whole service worker.
+ */
+import { SITE_TOGGLE_STORAGE_KEY, type SiteId } from '../shared/types.js';
+
+type ToggleState = Record<string, boolean>;
+
+let cache: ToggleState | null = null;
+
+async function readStorage(): Promise<ToggleState> {
+  try {
+    const res = await chrome.storage.local.get(SITE_TOGGLE_STORAGE_KEY);
+    const value = res[SITE_TOGGLE_STORAGE_KEY];
+    if (value && typeof value === 'object') return value as ToggleState;
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+export async function isSiteEnabled(source: SiteId): Promise<boolean> {
+  if (!cache) cache = await readStorage();
+  return cache[source] !== false;
+}
+
+export function installToggleSubscription(): void {
+  try {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area !== 'local') return;
+      const delta = changes[SITE_TOGGLE_STORAGE_KEY];
+      if (!delta) return;
+      cache = (delta.newValue as ToggleState | undefined) ?? {};
+    });
+  } catch {
+    // storage API not available (test harness)
+  }
+}
+
+/** Test-only: reset the in-process cache. */
+export function __resetToggleCacheForTests(): void {
+  cache = null;
+}

--- a/packages/browser-extension/src/content/base-hook.ts
+++ b/packages/browser-extension/src/content/base-hook.ts
@@ -1,4 +1,4 @@
-import type { CapturedPrompt, SiteId } from '../shared/types.js';
+import type { CapturedPrompt, Message, SiteId } from '../shared/types.js';
 
 export interface PromptHook {
   readonly siteId: SiteId;
@@ -17,6 +17,8 @@ export interface PromptHook {
  * a PromptHook implementation.
  */
 export function activate(hook: PromptHook): void {
+  announceLoaded(hook.siteId);
+
   const root = hook.findInputRoot();
   if (root) {
     install(hook, root);
@@ -33,6 +35,18 @@ export function activate(hook: PromptHook): void {
   obs.observe(document.documentElement, { childList: true, subtree: true });
 }
 
+function announceLoaded(source: SiteId): void {
+  try {
+    const msg: Message = { kind: 'content-loaded', source };
+    chrome.runtime.sendMessage(msg, () => {
+      // swallow lastError — the page may outlive the service worker
+      void chrome.runtime.lastError;
+    });
+  } catch {
+    // no-op — runtime may be restarting
+  }
+}
+
 function install(hook: PromptHook, root: HTMLElement): void {
   const dispose = hook.onSubmit(root, (prompt) => {
     if (!prompt || prompt.trim().length === 0) return;
@@ -43,8 +57,9 @@ function install(hook: PromptHook, root: HTMLElement): void {
       captured_at: new Date().toISOString(),
     };
     try {
-      chrome.runtime.sendMessage({ kind: 'prompt', payload }, () => {
-        // response is IngestResult; we don't need to act on it here
+      chrome.runtime.sendMessage({ kind: 'prompt', payload } satisfies Message, () => {
+        // response is IngestResult; background handles badge update
+        void chrome.runtime.lastError;
       });
     } catch {
       // background may be restarting — lose the ping rather than crash the page.

--- a/packages/browser-extension/src/content/chatgpt.ts
+++ b/packages/browser-extension/src/content/chatgpt.ts
@@ -14,8 +14,10 @@ const chatgpt: PromptHook = {
 
   readPrompt(root) {
     if (root instanceof HTMLTextAreaElement) return root.value;
-    // contenteditable — innerText preserves line breaks roughly
-    return (root as HTMLElement).innerText;
+    // contenteditable — innerText preserves line breaks roughly. Fall back
+    // to textContent so jsdom unit tests still see user text.
+    const el = root as HTMLElement;
+    return el.innerText || el.textContent || '';
   },
 
   onSubmit(root, cb) {

--- a/packages/browser-extension/src/content/claude-ai.ts
+++ b/packages/browser-extension/src/content/claude-ai.ts
@@ -11,7 +11,10 @@ const claudeAi: PromptHook = {
   },
 
   readPrompt(root) {
-    return (root as HTMLElement).innerText;
+    // jsdom does not implement `innerText`; fall back to `textContent` so
+    // unit tests and headless environments still capture user text.
+    const el = root as HTMLElement;
+    return (el.innerText || el.textContent || '').trim();
   },
 
   onSubmit(root, cb) {

--- a/packages/browser-extension/src/content/gemini.ts
+++ b/packages/browser-extension/src/content/gemini.ts
@@ -11,7 +11,8 @@ const gemini: PromptHook = {
   },
 
   readPrompt(root) {
-    return (root as HTMLElement).innerText;
+    const el = root as HTMLElement;
+    return (el.innerText || el.textContent || '').trim();
   },
 
   onSubmit(root, cb) {

--- a/packages/browser-extension/src/content/genspark.ts
+++ b/packages/browser-extension/src/content/genspark.ts
@@ -12,7 +12,8 @@ const genspark: PromptHook = {
 
   readPrompt(root) {
     if (root instanceof HTMLTextAreaElement) return root.value;
-    return (root as HTMLElement).innerText;
+    const el = root as HTMLElement;
+    return el.innerText || el.textContent || '';
   },
 
   onSubmit(root, cb) {

--- a/packages/browser-extension/src/content/perplexity.ts
+++ b/packages/browser-extension/src/content/perplexity.ts
@@ -11,7 +11,9 @@ const perplexity: PromptHook = {
   },
 
   readPrompt(root) {
-    return (root as HTMLTextAreaElement).value ?? (root as HTMLElement).innerText;
+    if (root instanceof HTMLTextAreaElement) return root.value;
+    const el = root as HTMLElement;
+    return el.innerText || el.textContent || '';
   },
 
   onSubmit(root, cb) {

--- a/packages/browser-extension/src/popup/index.html
+++ b/packages/browser-extension/src/popup/index.html
@@ -37,6 +37,10 @@
       <span class="label">Synced</span>
       <span id="synced">0</span>
     </div>
+    <div class="row">
+      <span class="label">Stuck (retry cap)</span>
+      <span id="poisoned">0</span>
+    </div>
     <button id="sync-btn">Sync now</button>
     <button id="options-btn">Settings</button>
     <p class="hint">Your prompts never leave this device. See <a href="../privacy-policy.html" target="_blank">privacy policy</a>.</p>

--- a/packages/browser-extension/src/popup/popup.ts
+++ b/packages/browser-extension/src/popup/popup.ts
@@ -15,12 +15,14 @@ async function refreshStats(): Promise<void> {
   }
   chrome.runtime.sendMessage(
     { kind: 'stats' },
-    (res: { total: number; synced: number; pending: number } | undefined) => {
+    (res: { total: number; synced: number; pending: number; poisoned?: number } | undefined) => {
       if (!res) return;
       const p = document.getElementById('pending');
       const s = document.getElementById('synced');
+      const x = document.getElementById('poisoned');
       if (p) p.textContent = String(res.pending);
       if (s) s.textContent = String(res.synced);
+      if (x) x.textContent = String(res.poisoned ?? 0);
     }
   );
 }

--- a/packages/browser-extension/src/shared/pii.ts
+++ b/packages/browser-extension/src/shared/pii.ts
@@ -21,6 +21,11 @@ const PATTERNS: Array<{ kind: string; re: RegExp; token: string }> = [
   { kind: 'rrn', re: /\b\d{6}-?[1-4]\d{6}\b/g, token: '<RRN>' },
   { kind: 'credit_card', re: /\b(?:\d[ -]?){13,19}\b/g, token: '<CARD>' },
   { kind: 'phone_kr', re: /\b0\d{1,2}[- .]?\d{3,4}[- .]?\d{4}\b/g, token: '<PHONE>' },
+  {
+    kind: 'phone_intl',
+    re: /\+\d{1,3}[- .]?\d{2,4}[- .]?\d{3,4}[- .]?\d{3,4}/g,
+    token: '<PHONE>',
+  },
   { kind: 'aws_akid', re: /\bAKIA[0-9A-Z]{16}\b/g, token: '<AWS_KEY>' },
   { kind: 'aws_asia', re: /\bASIA[0-9A-Z]{16}\b/g, token: '<AWS_KEY>' },
   { kind: 'github_token', re: /\bghp_[A-Za-z0-9]{36}\b/g, token: '<GITHUB_TOKEN>' },

--- a/packages/browser-extension/src/shared/types.ts
+++ b/packages/browser-extension/src/shared/types.ts
@@ -19,6 +19,17 @@ export interface IngestResult {
   hits?: Array<{ rule_id: string; severity: number; message: string }>;
   /** Present only when the local agent is unreachable and we queued the row. */
   queued?: true;
+  /** Present when the user has turned capture off for this site in Options. */
+  disabled?: true;
+  /** Optional error message surfaced to content-script callers. */
+  error?: string;
 }
 
-export type Message = { kind: 'prompt'; payload: CapturedPrompt };
+export type Message =
+  | { kind: 'prompt'; payload: CapturedPrompt }
+  | { kind: 'content-loaded'; source: SiteId }
+  | { kind: 'stats' }
+  | { kind: 'sync-now' };
+
+/** chrome.storage.local key for the per-site on/off toggle (read by background). */
+export const SITE_TOGGLE_STORAGE_KEY = 'think-prompt:sites';

--- a/packages/browser-extension/test/chatgpt-adapter.test.ts
+++ b/packages/browser-extension/test/chatgpt-adapter.test.ts
@@ -43,8 +43,9 @@ describe('chatgpt adapter', () => {
 
     const sendMessage = (globalThis as any).chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
     expect(sendMessage).toHaveBeenCalled();
-    const [msg] = sendMessage.mock.calls[0]!;
-    expect(msg.kind).toBe('prompt');
+    const promptCall = sendMessage.mock.calls.find((c) => (c[0] as any)?.kind === 'prompt');
+    expect(promptCall).toBeDefined();
+    const msg = promptCall![0] as any;
     expect(msg.payload.source).toBe('chatgpt');
     expect(msg.payload.prompt_text).toBe('이 코드 좀 봐줘');
     expect(msg.payload.browser_session_id).toBe('test-session-abc');

--- a/packages/browser-extension/test/claude-ai-adapter.test.ts
+++ b/packages/browser-extension/test/claude-ai-adapter.test.ts
@@ -1,0 +1,48 @@
+/**
+ * jsdom smoke test for the Claude.ai adapter.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  (globalThis as any).chrome = {
+    runtime: {
+      sendMessage: vi.fn((_msg: unknown, cb?: (r: unknown) => void) => cb?.({ ok: true })),
+    },
+  };
+  Object.defineProperty(window, 'performance', {
+    value: { timeOrigin: 1111 },
+    configurable: true,
+  });
+  Object.defineProperty(window, 'location', {
+    value: { pathname: '/chat/session-claude-42' },
+    writable: true,
+  });
+});
+
+describe('claude-ai adapter', () => {
+  it('captures a prompt when the Send Message button is clicked', async () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.className = 'ProseMirror';
+    editor.textContent = '이 PR 리뷰해줘';
+    document.body.appendChild(editor);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('aria-label', 'Send Message');
+    document.body.appendChild(btn);
+
+    const mod = await import('../src/content/claude-ai.js');
+    expect(mod.default).toBeTruthy();
+
+    btn.click();
+
+    const sendMessage = (globalThis as any).chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+    const promptCall = sendMessage.mock.calls.find((c) => (c[0] as any)?.kind === 'prompt');
+    expect(promptCall).toBeDefined();
+    const msg = promptCall![0] as any;
+    expect(msg.payload.source).toBe('claude-ai');
+    expect(msg.payload.prompt_text).toBe('이 PR 리뷰해줘');
+    expect(msg.payload.browser_session_id).toBe('session-claude-42');
+  });
+});

--- a/packages/browser-extension/test/e2e/extension-loads.spec.ts
+++ b/packages/browser-extension/test/e2e/extension-loads.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Smoke E2E: load the unpacked extension in a real Chromium instance and
+ * verify the service worker + options page boot without errors.
+ *
+ * This catches an entire class of regressions the jsdom suite can't:
+ *  - manifest.json parse errors
+ *  - module-script loading failures in MV3 service workers
+ *  - content script syntax errors caught only when Chromium parses them
+ *
+ * Requires `pnpm exec playwright install chromium` once.
+ */
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, expect, test } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const EXT_PATH = resolve(dirname(__filename), '..', '..', 'dist');
+
+test.beforeAll(() => {
+  if (!existsSync(EXT_PATH)) {
+    throw new Error(
+      `dist/ not found at ${EXT_PATH} — run \`pnpm -F @think-prompt/browser-extension build\` first`
+    );
+  }
+});
+
+test('extension loads and options page renders', async (_fixtures, testInfo) => {
+  testInfo.skip(
+    !process.env.PLAYWRIGHT_CHROMIUM_AVAILABLE,
+    'Set PLAYWRIGHT_CHROMIUM_AVAILABLE=1 after `playwright install chromium` to run.'
+  );
+
+  const userDataDir = await testInfo.outputPath('user-data');
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: false, // MV3 service workers need a non-headless context
+    args: [
+      `--disable-extensions-except=${EXT_PATH}`,
+      `--load-extension=${EXT_PATH}`,
+      '--no-first-run',
+      '--no-default-browser-check',
+    ],
+  });
+
+  try {
+    // Wait for the service worker to register.
+    let worker = context.serviceWorkers()[0];
+    if (!worker) {
+      worker = await context.waitForEvent('serviceworker');
+    }
+    expect(worker.url()).toContain('background/index.js');
+
+    // Open the options page under chrome-extension://<id>/options/index.html
+    const extId = new URL(worker.url()).host;
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extId}/options/index.html`);
+    await expect(page.locator('h1')).toHaveText(/Think-Prompt for Web/i);
+  } finally {
+    await context.close();
+  }
+});

--- a/packages/browser-extension/test/e2e/fixtures/chatgpt-stub.html
+++ b/packages/browser-extension/test/e2e/fixtures/chatgpt-stub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>ChatGPT stub (E2E fixture)</title>
+  </head>
+  <body>
+    <!-- Minimum DOM the adapter looks for. Keep selectors identical to
+         content/chatgpt.ts so a real DOM drift will surface here. -->
+    <textarea id="prompt-textarea" placeholder="Ask anything"></textarea>
+    <button data-testid="send-button">Send</button>
+  </body>
+</html>

--- a/packages/browser-extension/test/gemini-adapter.test.ts
+++ b/packages/browser-extension/test/gemini-adapter.test.ts
@@ -1,0 +1,50 @@
+/**
+ * jsdom smoke test for the Gemini adapter.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  (globalThis as any).chrome = {
+    runtime: {
+      sendMessage: vi.fn((_msg: unknown, cb?: (r: unknown) => void) => cb?.({ ok: true })),
+    },
+  };
+  Object.defineProperty(window, 'performance', {
+    value: { timeOrigin: 2222 },
+    configurable: true,
+  });
+  Object.defineProperty(window, 'location', {
+    value: { pathname: '/app/gemini-abc-999' },
+    writable: true,
+  });
+});
+
+describe('gemini adapter', () => {
+  it('captures a prompt when a Send-labeled button is clicked', async () => {
+    const wrapper = document.createElement('rich-textarea');
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.className = 'ql-editor';
+    editor.textContent = 'summarize this paper';
+    wrapper.appendChild(editor);
+    document.body.appendChild(wrapper);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('aria-label', 'Send message');
+    document.body.appendChild(btn);
+
+    const mod = await import('../src/content/gemini.js');
+    expect(mod.default).toBeTruthy();
+
+    btn.click();
+
+    const sendMessage = (globalThis as any).chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+    const promptCall = sendMessage.mock.calls.find((c) => (c[0] as any)?.kind === 'prompt');
+    expect(promptCall).toBeDefined();
+    const msg = promptCall![0] as any;
+    expect(msg.payload.source).toBe('gemini');
+    expect(msg.payload.prompt_text).toBe('summarize this paper');
+    expect(msg.payload.browser_session_id).toBe('gemini-abc-999');
+  });
+});

--- a/packages/browser-extension/test/genspark-adapter.test.ts
+++ b/packages/browser-extension/test/genspark-adapter.test.ts
@@ -1,0 +1,46 @@
+/**
+ * jsdom smoke test for the Genspark adapter.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  (globalThis as any).chrome = {
+    runtime: {
+      sendMessage: vi.fn((_msg: unknown, cb?: (r: unknown) => void) => cb?.({ ok: true })),
+    },
+  };
+  Object.defineProperty(window, 'performance', {
+    value: { timeOrigin: 4444 },
+    configurable: true,
+  });
+  Object.defineProperty(window, 'location', {
+    value: { pathname: '/search/gs-7777' },
+    writable: true,
+  });
+});
+
+describe('genspark adapter', () => {
+  it('captures a prompt when a button whose text matches /search|send|ask/ is clicked', async () => {
+    const ta = document.createElement('textarea');
+    ta.value = 'research query on climate';
+    document.body.appendChild(ta);
+
+    const btn = document.createElement('button');
+    btn.textContent = 'Search';
+    document.body.appendChild(btn);
+
+    const mod = await import('../src/content/genspark.js');
+    expect(mod.default).toBeTruthy();
+
+    btn.click();
+
+    const sendMessage = (globalThis as any).chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+    const promptCall = sendMessage.mock.calls.find((c) => (c[0] as any)?.kind === 'prompt');
+    expect(promptCall).toBeDefined();
+    const msg = promptCall![0] as any;
+    expect(msg.payload.source).toBe('genspark');
+    expect(msg.payload.prompt_text).toBe('research query on climate');
+    expect(msg.payload.browser_session_id).toBe('gs-7777');
+  });
+});

--- a/packages/browser-extension/test/perplexity-adapter.test.ts
+++ b/packages/browser-extension/test/perplexity-adapter.test.ts
@@ -1,0 +1,47 @@
+/**
+ * jsdom smoke test for the Perplexity adapter.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  (globalThis as any).chrome = {
+    runtime: {
+      sendMessage: vi.fn((_msg: unknown, cb?: (r: unknown) => void) => cb?.({ ok: true })),
+    },
+  };
+  Object.defineProperty(window, 'performance', {
+    value: { timeOrigin: 3333 },
+    configurable: true,
+  });
+  Object.defineProperty(window, 'location', {
+    value: { pathname: '/search/pplx-42' },
+    writable: true,
+  });
+});
+
+describe('perplexity adapter', () => {
+  it('captures a prompt when a submit-labeled button is clicked', async () => {
+    const ta = document.createElement('textarea');
+    ta.setAttribute('placeholder', 'Ask anything');
+    ta.value = 'what is RAG';
+    document.body.appendChild(ta);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('aria-label', 'Submit');
+    document.body.appendChild(btn);
+
+    const mod = await import('../src/content/perplexity.js');
+    expect(mod.default).toBeTruthy();
+
+    btn.click();
+
+    const sendMessage = (globalThis as any).chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+    const promptCall = sendMessage.mock.calls.find((c) => (c[0] as any)?.kind === 'prompt');
+    expect(promptCall).toBeDefined();
+    const msg = promptCall![0] as any;
+    expect(msg.payload.source).toBe('perplexity');
+    expect(msg.payload.prompt_text).toBe('what is RAG');
+    expect(msg.payload.browser_session_id).toBe('pplx-42');
+  });
+});

--- a/packages/browser-extension/test/pii.test.ts
+++ b/packages/browser-extension/test/pii.test.ts
@@ -13,6 +13,12 @@ describe('extension pii masker', () => {
     expect(r.masked).toContain('<PHONE>');
   });
 
+  it('masks international phone (phone_intl)', () => {
+    const r = maskPii('call me at +82 10 1234 5678 anytime');
+    expect(r.masked).toContain('<PHONE>');
+    expect(r.hits.phone_intl ?? r.hits.phone_kr).toBeGreaterThanOrEqual(1);
+  });
+
   it('masks Anthropic key before generic sk-', () => {
     const r = maskPii('key=sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234');
     expect(r.masked).toContain('<ANTHROPIC_KEY>');

--- a/packages/browser-extension/test/queue-retry.test.ts
+++ b/packages/browser-extension/test/queue-retry.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the retry-cap logic in the IndexedDB queue. The predicate
+ * governs whether drainPending() will pick a row up — mis-reading it would
+ * mean poisoned rows get retried forever (P2-9).
+ */
+import { describe, expect, it } from 'vitest';
+import { MAX_ATTEMPTS, type QueueRow, isRowRetriable } from '../src/background/queue.js';
+
+function row(partial: Partial<QueueRow>): QueueRow {
+  return {
+    id: 'x',
+    source: 'chatgpt',
+    browser_session_id: 'b',
+    prompt_text: 'hi',
+    pii_masked: 'hi',
+    pii_hits: {},
+    created_at: '2026-04-22T00:00:00Z',
+    synced: false,
+    attempts: 0,
+    ...partial,
+  };
+}
+
+describe('queue retry predicate', () => {
+  it('retriable when fresh', () => {
+    expect(isRowRetriable(row({}))).toBe(true);
+  });
+
+  it('not retriable once synced', () => {
+    expect(isRowRetriable(row({ synced: true }))).toBe(false);
+  });
+
+  it('not retriable once poisoned', () => {
+    expect(isRowRetriable(row({ poisoned: true }))).toBe(false);
+  });
+
+  it(`not retriable at ${MAX_ATTEMPTS} attempts`, () => {
+    expect(isRowRetriable(row({ attempts: MAX_ATTEMPTS }))).toBe(false);
+  });
+
+  it(`retriable at ${MAX_ATTEMPTS - 1} attempts`, () => {
+    expect(isRowRetriable(row({ attempts: MAX_ATTEMPTS - 1 }))).toBe(true);
+  });
+});

--- a/packages/browser-extension/test/site-toggle.test.ts
+++ b/packages/browser-extension/test/site-toggle.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Verifies that the per-site on/off toggle actually gates capture.
+ * Before v0.3.1 the Options page wrote this key but nothing read it,
+ * so it was silently a no-op — a privacy policy violation.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetToggleCacheForTests, isSiteEnabled } from '../src/background/site-toggle.js';
+
+const STORAGE_KEY = 'think-prompt:sites';
+
+function stubStorage(value: unknown): void {
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        get: vi.fn(async (key: string) => ({ [key]: value })),
+      },
+      onChanged: { addListener: vi.fn() },
+    },
+  };
+}
+
+beforeEach(() => {
+  __resetToggleCacheForTests();
+});
+
+describe('site toggle', () => {
+  it('treats missing entries as enabled (opt-out model)', async () => {
+    stubStorage(undefined);
+    await expect(isSiteEnabled('chatgpt')).resolves.toBe(true);
+  });
+
+  it('returns false when the user explicitly toggled the site off', async () => {
+    stubStorage({ chatgpt: false, 'claude-ai': true });
+    await expect(isSiteEnabled('chatgpt')).resolves.toBe(false);
+  });
+
+  it('returns true when storage has an empty record', async () => {
+    stubStorage({});
+    await expect(isSiteEnabled('gemini')).resolves.toBe(true);
+  });
+
+  it('returns true when storage access throws', async () => {
+    (globalThis as any).chrome = {
+      storage: {
+        local: {
+          get: vi.fn(async () => {
+            throw new Error('denied');
+          }),
+        },
+        onChanged: { addListener: vi.fn() },
+      },
+    };
+    await expect(isSiteEnabled('perplexity')).resolves.toBe(true);
+  });
+
+  it('caches the result — repeated calls hit storage once', async () => {
+    stubStorage({ chatgpt: false });
+    await isSiteEnabled('chatgpt');
+    await isSiteEnabled('chatgpt');
+    await isSiteEnabled('claude-ai');
+    const getMock = (globalThis as any).chrome.storage.local.get as ReturnType<typeof vi.fn>;
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/commands/config-cmd.ts
+++ b/packages/cli/src/commands/config-cmd.ts
@@ -1,8 +1,11 @@
 import { loadConfig, saveConfig, setConfigValue } from '@think-prompt/core';
 import pc from 'picocolors';
 
-function getDeep(obj: any, key: string): unknown {
-  return key.split('.').reduce((acc: any, k) => (acc == null ? undefined : acc[k]), obj);
+function getDeep(obj: unknown, key: string): unknown {
+  return key.split('.').reduce<unknown>((acc, k) => {
+    if (acc == null || typeof acc !== 'object') return undefined;
+    return (acc as Record<string, unknown>)[k];
+  }, obj);
 }
 
 function coerce(value: string): unknown {

--- a/packages/cli/src/commands/export-reprocess.ts
+++ b/packages/cli/src/commands/export-reprocess.ts
@@ -11,10 +11,12 @@ import {
 import { runRules } from '@think-prompt/rules';
 import pc from 'picocolors';
 
+type SqliteParam = string | number | null | bigint | Buffer;
+
 export async function exportCmd(opts: { since?: string; out: string }): Promise<void> {
   const db = openDb();
   let where = '';
-  const args: any[] = [];
+  const args: SqliteParam[] = [];
   if (opts.since) {
     where = `WHERE created_at > datetime('now', ?)`;
     const s = opts.since.startsWith('-') ? opts.since : `-${opts.since}`;
@@ -23,10 +25,10 @@ export async function exportCmd(opts: { since?: string; out: string }): Promise<
   }
   const usages = db
     .prepare(`SELECT * FROM prompt_usages ${where} ORDER BY created_at DESC`)
-    .all(...args) as any[];
-  const scores = db.prepare(`SELECT * FROM quality_scores`).all() as any[];
-  const hits = db.prepare(`SELECT * FROM rule_hits`).all() as any[];
-  const sessions = db.prepare(`SELECT * FROM sessions`).all() as any[];
+    .all(...args) as Record<string, unknown>[];
+  const scores = db.prepare(`SELECT * FROM quality_scores`).all() as Record<string, unknown>[];
+  const hits = db.prepare(`SELECT * FROM rule_hits`).all() as Record<string, unknown>[];
+  const sessions = db.prepare(`SELECT * FROM sessions`).all() as Record<string, unknown>[];
   const payload = {
     exported_at: new Date().toISOString(),
     usages,
@@ -50,13 +52,14 @@ export async function reprocessCmd(opts: { session?: string; all?: boolean }): P
     word_count: number;
     cwd: string;
   }[] = [];
+  type ReprocessTarget = (typeof targets)[number];
   if (opts.all) {
     const rows = db
       .prepare(
         `SELECT pu.id, pu.prompt_text, pu.session_id, pu.char_len, pu.word_count, s.cwd
            FROM prompt_usages pu JOIN sessions s ON s.id = pu.session_id`
       )
-      .all() as any[];
+      .all() as ReprocessTarget[];
     targets.push(...rows);
   } else if (opts.session) {
     const rows = db
@@ -65,7 +68,7 @@ export async function reprocessCmd(opts: { session?: string; all?: boolean }): P
            FROM prompt_usages pu JOIN sessions s ON s.id = pu.session_id
           WHERE pu.session_id = ?`
       )
-      .all(opts.session) as any[];
+      .all(opts.session) as ReprocessTarget[];
     targets.push(...rows);
   } else {
     console.log(pc.red('pass --all or --session <id>'));

--- a/packages/cli/src/commands/rewrite.ts
+++ b/packages/cli/src/commands/rewrite.ts
@@ -22,9 +22,14 @@ export async function rewriteCmd(id: string, opts: { copy?: boolean }): Promise<
   const db = openDb();
   const config = loadConfig();
   const paths = getPaths();
+  interface UsageRow {
+    id: string;
+    prompt_text: string;
+    pii_masked: string;
+  }
   const u = db
     .prepare(`SELECT * FROM prompt_usages WHERE id=? OR id LIKE ? ORDER BY created_at DESC LIMIT 1`)
-    .get(id, `%${id}`) as any;
+    .get(id, `%${id}`) as UsageRow | undefined;
   if (!u) {
     console.log(pc.red('no matching prompt'));
     db.close();
@@ -46,9 +51,14 @@ export async function rewriteCmd(id: string, opts: { copy?: boolean }): Promise<
     return;
   }
 
+  interface RuleHitRow {
+    rule_id: string;
+    severity: number;
+    message: string;
+  }
   const hits = db
     .prepare(`SELECT rule_id, severity, message FROM rule_hits WHERE usage_id=?`)
-    .all(u.id) as any[];
+    .all(u.id) as RuleHitRow[];
   const body = [
     '[ORIGINAL PROMPT]',
     u.pii_masked,

--- a/packages/cli/src/commands/show.ts
+++ b/packages/cli/src/commands/show.ts
@@ -1,12 +1,42 @@
 import { openDb } from '@think-prompt/core';
 import pc from 'picocolors';
 
-function matchUsage(db: any, id: string): any | undefined {
+interface UsageRow {
+  id: string;
+  session_id: string;
+  prompt_text: string;
+  char_len: number;
+  word_count: number;
+  turn_index: number;
+  created_at: string;
+}
+interface QualityScoreRow {
+  rule_score: number;
+  usage_score: number | null;
+  judge_score: number | null;
+  final_score: number;
+  tier: string;
+}
+interface RuleHitRow {
+  rule_id: string;
+  severity: number;
+  message: string;
+}
+interface RewriteRow {
+  status: string;
+  after_text: string;
+  reason: string | null;
+}
+
+type DbHandle = ReturnType<typeof openDb>;
+
+function matchUsage(db: DbHandle, id: string): UsageRow | undefined {
   // Allow short suffix matching for convenience.
-  if (id.length === 26) return db.prepare(`SELECT * FROM prompt_usages WHERE id=?`).get(id);
+  if (id.length === 26)
+    return db.prepare(`SELECT * FROM prompt_usages WHERE id=?`).get(id) as UsageRow | undefined;
   return db
     .prepare(`SELECT * FROM prompt_usages WHERE id LIKE ? ORDER BY created_at DESC LIMIT 1`)
-    .get(`%${id}`);
+    .get(`%${id}`) as UsageRow | undefined;
 }
 
 export async function showCmd(id: string): Promise<void> {
@@ -16,13 +46,15 @@ export async function showCmd(id: string): Promise<void> {
     console.log(pc.red('no matching prompt'));
     return;
   }
-  const score = db.prepare(`SELECT * FROM quality_scores WHERE usage_id=?`).get(u.id) as any;
+  const score = db.prepare(`SELECT * FROM quality_scores WHERE usage_id=?`).get(u.id) as
+    | QualityScoreRow
+    | undefined;
   const hits = db
     .prepare(`SELECT * FROM rule_hits WHERE usage_id=? ORDER BY severity DESC`)
-    .all(u.id) as any[];
+    .all(u.id) as RuleHitRow[];
   const rewrite = db
     .prepare(`SELECT * FROM rewrites WHERE usage_id=? ORDER BY created_at DESC LIMIT 1`)
-    .get(u.id) as any;
+    .get(u.id) as RewriteRow | undefined;
 
   console.log(pc.bold(`Prompt ${u.id}`));
   console.log(`  session: ${u.session_id}`);

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -129,6 +129,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     const q = (req.query as any) ?? {};
     const tierFilter = typeof q.tier === 'string' ? q.tier : undefined;
     const ruleFilter = typeof q.rule === 'string' ? q.rule : undefined;
+    const sourceFilter = typeof q.source === 'string' && q.source ? q.source : undefined;
     const wheres: string[] = [];
     const args: any[] = [];
     if (tierFilter) {
@@ -141,26 +142,58 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       );
       args.push(ruleFilter);
     }
+    if (sourceFilter) {
+      wheres.push('COALESCE(s.source, ?) = ?');
+      args.push('claude-code', sourceFilter);
+    }
     const where = wheres.length > 0 ? `WHERE ${wheres.join(' AND ')}` : '';
     const rows = db
       .prepare(
         `SELECT pu.id, substr(pu.prompt_text,1,160) AS snippet, pu.created_at, pu.char_len,
                 COALESCE(qs.final_score, -1) AS score, COALESCE(qs.tier, 'n/a') AS tier,
+                COALESCE(s.source, 'claude-code') AS source,
                 (SELECT COUNT(*) FROM rule_hits rh WHERE rh.usage_id=pu.id) AS hits
            FROM prompt_usages pu
            LEFT JOIN quality_scores qs ON qs.usage_id = pu.id
+           LEFT JOIN sessions s ON s.id = pu.session_id
            ${where}
           ORDER BY pu.created_at DESC LIMIT 100`
       )
-      .all(...args) as any[];
+      .all(...args) as Array<{
+      id: string;
+      snippet: string;
+      created_at: string;
+      char_len: number;
+      score: number;
+      tier: string;
+      source: string;
+      hits: number;
+    }>;
+
+    const sourceOptions = [
+      'claude-code',
+      'chatgpt',
+      'claude-ai',
+      'gemini',
+      'perplexity',
+      'genspark',
+    ];
 
     const body = `
       <h1 class="text-2xl font-bold mb-4">Prompts</h1>
-      <form class="mb-4 flex gap-3 text-sm">
+      <form class="mb-4 flex gap-3 text-sm flex-wrap">
         <select name="tier" class="border rounded px-2 py-1 bg-white dark:bg-zinc-800">
           <option value="">All tiers</option>
           ${['good', 'ok', 'weak', 'bad']
             .map((t) => `<option value="${t}" ${tierFilter === t ? 'selected' : ''}>${t}</option>`)
+            .join('')}
+        </select>
+        <select name="source" class="border rounded px-2 py-1 bg-white dark:bg-zinc-800">
+          <option value="">All sources</option>
+          ${sourceOptions
+            .map(
+              (s) => `<option value="${s}" ${sourceFilter === s ? 'selected' : ''}>${s}</option>`
+            )
             .join('')}
         </select>
         <input name="rule" placeholder="rule id e.g. R003" value="${escapeHtml(ruleFilter ?? '')}"
@@ -173,6 +206,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
           <tr>
             <th class="p-2 w-16">Score</th>
             <th class="p-2 w-20">Tier</th>
+            <th class="p-2 w-24">Source</th>
             <th class="p-2 w-10">Hits</th>
             <th class="p-2">Prompt</th>
             <th class="p-2 w-40">Created</th>
@@ -185,6 +219,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                 `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}'">
                    <td class="p-2 font-mono">${r.score >= 0 ? r.score : '-'}</td>
                    <td class="p-2">${tierBadge(r.tier)}</td>
+                   <td class="p-2 text-xs text-gray-600 dark:text-zinc-300">${escapeHtml(r.source)}</td>
                    <td class="p-2 text-gray-500">${r.hits}</td>
                    <td class="p-2 truncate max-w-[32rem]">${escapeHtml(r.snippet)}</td>
                    <td class="p-2 text-gray-400 text-xs">${escapeHtml(r.created_at)}</td>

--- a/packages/worker/src/jobs.ts
+++ b/packages/worker/src/jobs.ts
@@ -44,7 +44,21 @@ export async function handleParseSubagentTranscript(
   payload: { session_id: string; agent_id: string; agent_transcript_path: string }
 ): Promise<'done' | 'retry'> {
   const text = safeReadFile(payload.agent_transcript_path, MAX_TRANSCRIPT_BYTES);
-  if (text == null) return 'retry';
+  if (text == null) {
+    // Transcript file no longer exists. Retrying will never succeed and just
+    // floods the DLQ — log the loss and move on so we don't block other jobs.
+    // The subagent row stays in whatever state it was; downstream UI tolerates
+    // it (status remains as last set by upsertSubagent).
+    ctx.logger.warn(
+      {
+        session_id: payload.session_id,
+        agent_id: payload.agent_id,
+        path: payload.agent_transcript_path,
+      },
+      'subagent transcript missing — dropping job'
+    );
+    return 'done';
+  }
   const events = tp.parseTranscriptString(text);
   const prompt_text = tp.extractFirstUserPrompt(events);
   const response_text = tp.extractFinalAssistantText(events);
@@ -65,7 +79,13 @@ export async function handleParseTranscript(
   payload: { session_id: string; transcript_path: string }
 ): Promise<'done' | 'retry'> {
   const text = safeReadFile(payload.transcript_path, MAX_TRANSCRIPT_BYTES);
-  if (text == null) return 'retry';
+  if (text == null) {
+    ctx.logger.warn(
+      { session_id: payload.session_id, path: payload.transcript_path },
+      'session transcript missing — dropping job'
+    );
+    return 'done';
+  }
   const events = tp.parseTranscriptString(text);
   const toolSummary = tp.summarizeToolUse(events);
 

--- a/packages/worker/test/jobs.test.ts
+++ b/packages/worker/test/jobs.test.ts
@@ -61,7 +61,7 @@ describe('worker jobs', () => {
     db.close();
   });
 
-  it('retries when transcript file missing', async () => {
+  it('drops job when transcript file missing (avoids DLQ flood)', async () => {
     const db = openDb(tmp);
     const logger = createLogger('test', { stdout: false, file: join(tmp, 'test.log') });
     const config = loadConfig(tmp);
@@ -69,7 +69,7 @@ describe('worker jobs', () => {
       { db, logger, config },
       { session_id: 's2', agent_id: 'a1', agent_transcript_path: '/nonexistent/file.jsonl' }
     );
-    expect(result).toBe('retry');
+    expect(result).toBe('done');
     db.close();
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@types/jsdom':
+        specifier: ^28.0.1
+        version: 28.0.1
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.17
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
@@ -52,6 +58,9 @@ importers:
         specifier: workspace:*
         version: link:../rules
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.59.1
       '@types/chrome':
         specifier: ^0.0.290
         version: 0.0.290
@@ -751,6 +760,11 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
@@ -907,8 +921,14 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/jsdom@28.0.1':
+    resolution: {integrity: sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -1199,6 +1219,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1404,6 +1429,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -1669,6 +1704,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.25.0:
+    resolution: {integrity: sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2111,6 +2149,10 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
@@ -2205,9 +2247,18 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/jsdom@28.0.1':
+    dependencies:
+      '@types/node': 22.19.17
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+      undici-types: 7.25.0
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -2568,6 +2619,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2783,6 +2837,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@6.0.1(postcss@8.5.10):
     dependencies:
@@ -3052,6 +3114,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.25.0: {}
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary / 요약

세션 외부에서 축적된 working-tree 변경을 **CI 검증 목적으로 한 브랜치로 묶은** bulk sync PR. 이 세션(autostart + 대시보드 개선)과 **별개의 작업**을 한꺼번에 수행·머지하기 위해 분리된 PR입니다.

A bulk-sync PR to **route CI validation through a single branch** for external changes that had accumulated in the working tree. Distinct from this session's autostart + dashboard improvements.

## Scope / 범위

| Area / 영역 | Notes |
|---|---|
| `packages/browser-extension/` (22 파일 수정 + 8 신규) | 어댑터 테스트 4종, Playwright E2E 스캐폴딩, queue-retry·site-toggle 기능 + 테스트 |
| `packages/agent/` (2 파일) | `/v1/ingest/web` 라우트 + 회귀 테스트 2건 |
| `packages/worker/` (2 파일) | `outcomes` 테이블 수정 — 이전 실패 3건 복구에 연결 |
| `packages/dashboard/` (1 파일) | server.ts 업데이트 |
| `packages/cli/src/commands/` (4 파일) | config, export-reprocess, rewrite, show 명령 업데이트 |
| `package.json`, `pnpm-lock.yaml` | `jsdom` + `@types/jsdom` (E2E fixture) |
| `docs/99-observation-log.md`, `REPORT.md` | 문서 갱신 |

## Local verification / 로컬 검증 (커밋 전)

- `pnpm typecheck` — 7/7 packages clean ✅
- `pnpm test` — **144/144 pass** ✅ (이전 128, +16 브라우저 확장)
- **이 세션에서 새로 만든 Playwright `.spec.ts` 파일은 vitest가 안 잡고 별도 runner 필요** — 실제 브라우저 실행은 CI 설정에 의존.

## Review notes / 리뷰 참고

- 이 커밋은 **세션 작성자(Claude Code)가 설계·작성한 feature가 아님**. working tree에 있던 외부 작업을 묶어 CI로 검증한 것.
- 설계 근거는 개별 파일 히스토리 / `docs/*.md` / 각 파일 주석을 참조.
- 머지 전략: **CI 그린 확인 후 squash merge** 예정.

## Test plan / 테스트 계획

- [ ] CI pass (Ubuntu × macOS × Node 20/22)
- [ ] 머지 후 main에서 `pnpm test` 재확인 (로컬)
- [ ] 브라우저 확장 실제 페이지 동작은 별도 실측 필요 (scope out)