### PR TITLE
feat(dashboard): 5개 언어 i18n 적용 + 차트 아래 일별 리스트 제거 + 자동 새로고침 / Apply 5-lang i18n, drop daily list, add live-refresh

### DIFF
--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -1,3 +1,5 @@
+import { LOCALE_LABELS, type Locale, t } from './i18n.js';
+
 export function escapeHtml(s: unknown): string {
   return String(s ?? '')
     .replace(/&/g, '&amp;')
@@ -7,9 +9,43 @@ export function escapeHtml(s: unknown): string {
     .replace(/'/g, '&#39;');
 }
 
-export function layout(title: string, body: string): string {
+export interface LayoutOptions {
+  /** `reqPath` + `reqQuery` preserve current URL when switching language. */
+  reqPath?: string;
+  reqQuery?: Record<string, string>;
+  /**
+   * Opt-in live refresh. When true, the page polls the agent's latest
+   * prompt-usage id every N seconds and reloads on change. Only enabled
+   * on views whose data changes on new-prompt arrival (Overview, Prompts
+   * list) — leave off on detail pages to preserve scroll/inputs.
+   */
+  liveRefresh?: boolean;
+}
+
+export function layout(
+  title: string,
+  body: string,
+  locale: Locale = 'en',
+  opts: LayoutOptions = {}
+): string {
+  const navItems: Array<[string, keyof typeof LABEL_KEYS]> = [
+    ['/', 'nav.overview'],
+    ['/prompts', 'nav.prompts'],
+    ['/rules', 'nav.rules'],
+    ['/settings', 'nav.settings'],
+    ['/doctor', 'nav.doctor'],
+  ];
+  const navHtml = navItems
+    .map(([href, key]) => {
+      const url = appendLangParam(href, locale);
+      return `<a href="${url}" class="hover:text-blue-600">${escapeHtml(t(locale, key))}</a>`;
+    })
+    .join('');
+  const langSwitcher = renderLanguageSwitcher(locale, opts);
+  const liveScript = opts.liveRefresh ? LIVE_REFRESH_SCRIPT : '';
+
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="${locale}">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -29,34 +65,129 @@ export function layout(title: string, body: string): string {
   <header class="bg-white dark:bg-zinc-800 border-b border-gray-200 dark:border-zinc-700">
     <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
       <div class="flex items-center gap-6">
-        <a href="/" class="text-xl font-bold">Think-Prompt</a>
+        <a href="${appendLangParam('/', locale)}" class="text-xl font-bold">Think-Prompt</a>
         <nav class="text-sm flex gap-4 text-gray-600 dark:text-zinc-300">
-          <a href="/" class="hover:text-blue-600">Overview</a>
-          <a href="/prompts" class="hover:text-blue-600">Prompts</a>
-          <a href="/rules" class="hover:text-blue-600">Rules</a>
-          <a href="/settings" class="hover:text-blue-600">Settings</a>
-          <a href="/doctor" class="hover:text-blue-600">Doctor</a>
+          ${navHtml}
         </nav>
       </div>
-      <div class="text-xs text-gray-400">local-only · ${new Date().toISOString().slice(0, 10)}</div>
+      <div class="flex items-center gap-4">
+        ${langSwitcher}
+        <div class="text-xs text-gray-400">${escapeHtml(t(locale, 'footer.local_only'))} · ${new Date().toISOString().slice(0, 10)}</div>
+      </div>
     </div>
   </header>
   <main class="max-w-6xl mx-auto px-6 py-6">
 ${body}
   </main>
+  ${liveScript}
 </body>
 </html>`;
 }
 
-export function tierBadge(tier: string): string {
-  const map: Record<string, string> = {
+/**
+ * Append ?lang=<locale> to a path, preserving any existing query string.
+ * Used so the locale the user chose survives navigation.
+ */
+function appendLangParam(href: string, locale: Locale): string {
+  const [path, existingQuery = ''] = href.split('?');
+  const params = new URLSearchParams(existingQuery);
+  params.set('lang', locale);
+  return `${path}?${params.toString()}`;
+}
+
+function renderLanguageSwitcher(locale: Locale, opts: LayoutOptions): string {
+  const basePath = opts.reqPath ?? '/';
+  const passthrough = { ...(opts.reqQuery ?? {}) };
+  // Remove lang so each option can inject its own.
+  delete passthrough.lang;
+  const queryPrefix = new URLSearchParams(passthrough).toString();
+  const sep = queryPrefix ? '&' : '';
+
+  const options = (['en', 'ko', 'zh', 'es', 'ja'] as Locale[])
+    .map((code) => {
+      const url = `${basePath}?${queryPrefix}${sep}lang=${code}`;
+      const selected = code === locale ? ' selected' : '';
+      return `<option value="${escapeHtml(url)}"${selected}>${escapeHtml(LOCALE_LABELS[code])}</option>`;
+    })
+    .join('');
+
+  return `<label class="text-xs text-gray-500 flex items-center gap-2">
+    <span class="sr-only">${escapeHtml(t(locale, 'common.language'))}</span>
+    <select
+      class="text-xs border border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 rounded px-2 py-1"
+      onchange="window.location=this.value"
+      aria-label="${escapeHtml(t(locale, 'common.language'))}">
+      ${options}
+    </select>
+  </label>`;
+}
+
+/**
+ * Polls /api/overview/latest-id every 6 seconds. When the watermark changes
+ * compared to the value captured at page render, the tab reloads.
+ *
+ * The polling script is injected only when layout() is called with
+ * liveRefresh:true — typically Overview and Prompts list.
+ *
+ * Kept inline (no external JS file) to stay consistent with the "no bundler"
+ * decision (D-012). ~30 lines is acceptable.
+ */
+const LIVE_REFRESH_SCRIPT = `<script>
+(function () {
+  const INITIAL = document.documentElement.getAttribute('data-latest-id') || '';
+  const INTERVAL_MS = 6000;
+  let stopped = false;
+  async function tick() {
+    if (stopped || document.hidden) return;
+    try {
+      const r = await fetch('/api/overview/latest-id', { cache: 'no-store' });
+      if (!r.ok) return;
+      const { latestId } = await r.json();
+      if (latestId && latestId !== INITIAL) {
+        stopped = true;
+        location.reload();
+      }
+    } catch (_) {
+      // Network blip — try again next tick.
+    }
+  }
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden && !stopped) tick();
+  });
+  setInterval(tick, INTERVAL_MS);
+})();
+</script>`;
+
+// Used only for the typing of navItems key-list; kept here to avoid pulling
+// the whole Dictionary interface just for the nav labels.
+const LABEL_KEYS = {
+  'nav.overview': true,
+  'nav.prompts': true,
+  'nav.rules': true,
+  'nav.settings': true,
+  'nav.doctor': true,
+} as const;
+
+export function tierBadge(tier: string, locale: Locale = 'en'): string {
+  const classMap: Record<string, string> = {
     good: 'bg-green-100 text-green-800',
     ok: 'bg-yellow-100 text-yellow-800',
     weak: 'bg-orange-100 text-orange-800',
     bad: 'bg-red-100 text-red-800',
   };
-  const cls = map[tier] ?? 'bg-gray-100 text-gray-800';
-  return `<span class="inline-block px-2 py-0.5 text-xs rounded ${cls}">${escapeHtml(tier)}</span>`;
+  const cls = classMap[tier] ?? 'bg-gray-100 text-gray-800';
+  const labelKey =
+    tier === 'good'
+      ? 'tier.good'
+      : tier === 'ok'
+        ? 'tier.ok'
+        : tier === 'weak'
+          ? 'tier.weak'
+          : tier === 'bad'
+            ? 'tier.bad'
+            : 'tier.na';
+  const label = t(locale, labelKey);
+  return `<span class="inline-block px-2 py-0.5 text-xs rounded ${cls}">${escapeHtml(label)}</span>`;
 }
 
 export interface DailyBucket {
@@ -70,13 +201,12 @@ export interface DailyBucket {
 }
 
 /**
- * Inline SVG stacked bar chart — no JS, no external lib. Each bar is one day
- * and the segments (bottom-up: good → ok → weak → bad → n/a) match tierBadge
- * colors so the chart and the breakdown card read consistently.
+ * Inline SVG stacked bar chart. Each bar is one day, segments are tiers
+ * (bottom-up: good → ok → weak → bad → n/a). Daily totals sit above the bar.
  *
- * Design: the chart is layout-responsive (width 100%), uses viewBox so it
- * scales cleanly on dark/light, and labels the daily total above each bar
- * so the user never has to eyeball the segment heights.
+ * The X-axis shows every other day label when there are more than 10 bars
+ * (to avoid crowding); the full list-below-the-chart was removed at user
+ * request so the chart carries the whole daily view on its own.
  */
 export function renderDailyChart(data: DailyBucket[]): string {
   const W = 640;
@@ -91,7 +221,6 @@ export function renderDailyChart(data: DailyBucket[]): string {
   const slot = innerW / n;
   const barW = Math.max(6, Math.floor(slot * 0.7));
   const maxRaw = Math.max(1, ...data.map((d) => d.total));
-  // Round up to a "nice" axis max so y-gridlines land on integers.
   const niceMax = niceCeil(maxRaw);
   const yOf = (v: number): number => padT + innerH - (v / niceMax) * innerH;
   const xOf = (i: number): number => padL + slot * i + (slot - barW) / 2;
@@ -104,20 +233,18 @@ export function renderDailyChart(data: DailyBucket[]): string {
     na: '#9ca3af',
   } as const;
 
-  // 4 gridlines + axis
-  const ticks = [0, 0.25, 0.5, 0.75, 1].map((t) => Math.round(niceMax * t));
+  const ticks = [0, 0.25, 0.5, 0.75, 1].map((t0) => Math.round(niceMax * t0));
   const gridLines = ticks
     .map(
-      (t) =>
-        `<line x1="${padL}" y1="${yOf(t)}" x2="${W - padR}" y2="${yOf(t)}" stroke="currentColor" stroke-opacity="0.08" />
-         <text x="${padL - 6}" y="${yOf(t) + 3}" text-anchor="end" font-size="10" fill="currentColor" fill-opacity="0.5">${t}</text>`
+      (tv) =>
+        `<line x1="${padL}" y1="${yOf(tv)}" x2="${W - padR}" y2="${yOf(tv)}" stroke="currentColor" stroke-opacity="0.08" />
+         <text x="${padL - 6}" y="${yOf(tv) + 3}" text-anchor="end" font-size="10" fill="currentColor" fill-opacity="0.5">${tv}</text>`
     )
     .join('');
 
   const bars = data
     .map((d, i) => {
       const x = xOf(i);
-      // Stack bottom-up
       let runY = yOf(0);
       const seg = (value: number, color: string): string => {
         if (value <= 0) return '';
@@ -136,7 +263,6 @@ export function renderDailyChart(data: DailyBucket[]): string {
         d.total > 0
           ? `<text x="${x + barW / 2}" y="${runY - 4}" text-anchor="middle" font-size="10" font-family="ui-monospace, Menlo, monospace" fill="currentColor" fill-opacity="0.7">${d.total}</text>`
           : '';
-      // Show MM/DD every other day when >10 bars to avoid label crowding
       const showLabel = n <= 10 || i % 2 === 0 || i === n - 1;
       const [, mm, dd] = d.day.split('-');
       const dayLabel = showLabel

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -8,8 +8,9 @@ import {
   recordOutcome,
 } from '@think-prompt/core';
 import { getRulesCatalog } from '@think-prompt/rules';
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyRequest } from 'fastify';
 import { escapeHtml, layout, renderDailyChart, tierBadge } from './html.js';
+import { type Locale, resolveLocale, t } from './i18n.js';
 
 export interface DashboardDeps {
   config?: Config;
@@ -39,9 +40,47 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     }
   );
 
+  /**
+   * Resolve the locale for a request: ?lang= query → Accept-Language
+   * header → saved config.i18n → 'en'. See i18n.ts for details.
+   */
+  function reqLocale(req: FastifyRequest): Locale {
+    const accept = req.headers['accept-language'];
+    return resolveLocale(req.query, typeof accept === 'string' ? accept : undefined, config.i18n);
+  }
+
+  /** Preserved query string (minus lang) so the language switcher can round-trip. */
+  function reqQueryPassthrough(req: FastifyRequest): Record<string, string> {
+    const q = (req.query as Record<string, unknown> | null | undefined) ?? {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(q)) {
+      if (typeof v === 'string') out[k] = v;
+    }
+    return out;
+  }
+
+  /** Fresh watermark for the live-refresh poll. */
+  function latestPromptId(): string | null {
+    const row = db.prepare(`SELECT id FROM prompt_usages ORDER BY created_at DESC LIMIT 1`).get() as
+      | { id: string }
+      | undefined;
+    return row?.id ?? null;
+  }
+
+  /** Inject the current latestId so the polling script can diff it. */
+  function latestIdBootScript(id: string | null): string {
+    return `<script>document.documentElement.setAttribute('data-latest-id', ${JSON.stringify(id ?? '')});</script>`;
+  }
+
   fastify.get('/health', async () => ({ ok: true }));
 
-  fastify.get('/', async (_req, reply) => {
+  /** Live-refresh polling target — cheap, returns JSON, no HTML. */
+  fastify.get('/api/overview/latest-id', async () => {
+    return { latestId: latestPromptId() };
+  });
+
+  fastify.get('/', async (req, reply) => {
+    const locale = reqLocale(req);
     const totals = db.prepare(`SELECT COUNT(*) AS c FROM prompt_usages`).get() as { c: number };
 
     // All-time tier breakdown — force all statuses into the result even when 0.
@@ -57,12 +96,13 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       tierRows.map((r) => [r.tier, r.c])
     );
     const ALL_TIERS = ['good', 'ok', 'weak', 'bad', 'n/a'] as const;
-    const tierCounts = ALL_TIERS.map((t) => ({ tier: t, c: tierCountMap[t] ?? 0 }));
+    const tierCounts = ALL_TIERS.map((tierId) => ({
+      tier: tierId,
+      c: tierCountMap[tierId] ?? 0,
+    }));
     const tierTotal = tierCounts.reduce((acc, r) => acc + r.c, 0);
 
-    // Daily tier breakdown for the last 14 days. We compute the day axis from
-    // "today" so empty days still show up as an empty bar (easier to read
-    // than a ragged chart that skips silent days).
+    // Daily tier breakdown for the last N days.
     const DAYS = 14;
     const dailyRows = db
       .prepare(
@@ -136,41 +176,26 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
 
     const tierHtml = tierCounts
       .map(
-        (t) =>
-          `<div class="flex items-center gap-2"><span class="font-mono text-sm">${t.c}</span>${tierBadge(t.tier)}</div>`
+        (tc) =>
+          `<div class="flex items-center gap-2"><span class="font-mono text-sm">${tc.c}</span>${tierBadge(tc.tier, locale)}</div>`
       )
       .join('');
 
     const chartHtml = renderDailyChart(days);
-    const dailyListHtml = days
-      .map(
-        (d) =>
-          `<div class="flex items-center justify-between text-xs py-1 border-b border-gray-100 dark:border-zinc-700 last:border-0">
-             <span class="text-gray-500 font-mono">${escapeHtml(d.day)}</span>
-             <span class="flex items-center gap-2">
-               ${d.good ? `<span class="text-xs font-mono" style="color:#16a34a">${d.good}</span>` : ''}
-               ${d.ok ? `<span class="text-xs font-mono" style="color:#ca8a04">${d.ok}</span>` : ''}
-               ${d.weak ? `<span class="text-xs font-mono" style="color:#ea580c">${d.weak}</span>` : ''}
-               ${d.bad ? `<span class="text-xs font-mono" style="color:#dc2626">${d.bad}</span>` : ''}
-               ${d.na ? `<span class="text-xs font-mono" style="color:#6b7280">${d.na}</span>` : ''}
-               <span class="font-mono w-8 text-right">${d.total}</span>
-             </span>
-           </div>`
-      )
-      .join('');
 
     const body = `
-      <h1 class="text-2xl font-bold mb-6">Overview</h1>
+      ${latestIdBootScript(latestPromptId())}
+      <h1 class="text-2xl font-bold mb-6">${escapeHtml(t(locale, 'overview.title'))}</h1>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
         <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-5">
-          <div class="text-xs text-gray-500">Total prompts</div>
+          <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'overview.total_prompts'))}</div>
           <div class="text-3xl font-mono mt-2">${totals.c}</div>
-          <div class="text-xs text-gray-400 mt-1">last ${DAYS} days: ${windowTotal}</div>
+          <div class="text-xs text-gray-400 mt-1">${escapeHtml(t(locale, 'overview.last_n_days', { n: DAYS }))}: ${windowTotal}</div>
         </div>
         <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-5">
           <div class="flex items-center justify-between mb-3">
-            <div class="text-xs text-gray-500">Tier breakdown</div>
-            <div class="text-xs text-gray-400">total <span class="font-mono">${tierTotal}</span></div>
+            <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'overview.tier_breakdown'))}</div>
+            <div class="text-xs text-gray-400">${escapeHtml(t(locale, 'common.total'))} <span class="font-mono">${tierTotal}</span></div>
           </div>
           <div class="flex gap-3 flex-wrap">${tierHtml}</div>
         </div>
@@ -178,28 +203,25 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
 
       <section class="mb-8">
         <div class="flex items-center justify-between mb-3">
-          <h2 class="text-lg font-bold">Daily additions (last ${DAYS} days)</h2>
-          <div class="text-xs text-gray-500">total <span class="font-mono">${windowTotal}</span></div>
+          <h2 class="text-lg font-bold">${escapeHtml(t(locale, 'overview.daily_additions', { n: DAYS }))}</h2>
+          <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'common.total'))} <span class="font-mono">${windowTotal}</span></div>
         </div>
         <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
           ${chartHtml}
-          <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-x-8">
-            ${dailyListHtml}
-          </div>
         </div>
       </section>
 
       <section class="mb-8">
-        <h2 class="text-lg font-bold mb-3">Lowest scoring</h2>
+        <h2 class="text-lg font-bold mb-3">${escapeHtml(t(locale, 'overview.lowest_scoring'))}</h2>
         ${
           worst.length === 0
-            ? '<div class="text-gray-400 text-sm">no scored prompts yet</div>'
+            ? `<div class="text-gray-400 text-sm">${escapeHtml(t(locale, 'overview.no_scored_yet'))}</div>`
             : `<div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700">${worst
                 .map(
                   (r) =>
-                    `<a href="/prompts/${r.id}" class="flex items-center gap-4 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
+                    `<a href="/prompts/${r.id}?lang=${locale}" class="flex items-center gap-4 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
                        <span class="font-mono text-sm w-10 text-right">${r.final_score}</span>
-                       ${tierBadge(r.tier)}
+                       ${tierBadge(r.tier, locale)}
                        <span class="text-sm text-gray-700 dark:text-zinc-200 flex-1 truncate">${escapeHtml(r.snippet)}</span>
                      </a>`
                 )
@@ -208,14 +230,14 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       </section>
 
       <section>
-        <h2 class="text-lg font-bold mb-3">Recent</h2>
+        <h2 class="text-lg font-bold mb-3">${escapeHtml(t(locale, 'overview.recent'))}</h2>
         <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700">
           ${recent
             .map(
               (r) =>
-                `<a href="/prompts/${r.id}" class="flex items-center gap-4 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
+                `<a href="/prompts/${r.id}?lang=${locale}" class="flex items-center gap-4 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
                    <span class="font-mono text-sm w-10 text-right">${r.score >= 0 ? r.score : '-'}</span>
-                   ${tierBadge(r.tier)}
+                   ${tierBadge(r.tier, locale)}
                    <span class="text-xs text-gray-400 w-36">${escapeHtml(r.created_at)}</span>
                    <span class="text-sm text-gray-700 dark:text-zinc-200 flex-1 truncate">${escapeHtml(r.snippet)}</span>
                  </a>`
@@ -223,16 +245,23 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
             .join('')}
         </div>
       </section>`;
-    reply.type('text/html; charset=utf-8').send(layout('Overview', body));
+    reply.type('text/html; charset=utf-8').send(
+      layout(t(locale, 'overview.title'), body, locale, {
+        reqPath: '/',
+        reqQuery: reqQueryPassthrough(req),
+        liveRefresh: true,
+      })
+    );
   });
 
   fastify.get('/prompts', async (req, reply) => {
-    const q = (req.query ?? {}) as Record<string, unknown>;
+    const locale = reqLocale(req);
+    const q = (req.query as Record<string, unknown> | null | undefined) ?? {};
     const tierFilter = typeof q.tier === 'string' ? q.tier : undefined;
     const ruleFilter = typeof q.rule === 'string' ? q.rule : undefined;
-    const sourceFilter = typeof q.source === 'string' && q.source ? q.source : undefined;
+    const sourceFilter = typeof q.source === 'string' && q.source.length > 0 ? q.source : undefined;
     const wheres: string[] = [];
-    const args: (string | number | null)[] = [];
+    const args: unknown[] = [];
     if (tierFilter) {
       wheres.push('qs.tier = ?');
       args.push(tierFilter);
@@ -281,45 +310,50 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     ];
 
     const body = `
-      <h1 class="text-2xl font-bold mb-4">Prompts</h1>
+      ${latestIdBootScript(latestPromptId())}
+      <h1 class="text-2xl font-bold mb-4">${escapeHtml(t(locale, 'prompts.title'))}</h1>
       <form class="mb-4 flex gap-3 text-sm flex-wrap">
+        <input type="hidden" name="lang" value="${escapeHtml(locale)}" />
         <select name="tier" class="border rounded px-2 py-1 bg-white dark:bg-zinc-800">
-          <option value="">All tiers</option>
-          ${['good', 'ok', 'weak', 'bad']
-            .map((t) => `<option value="${t}" ${tierFilter === t ? 'selected' : ''}>${t}</option>`)
+          <option value="">${escapeHtml(t(locale, 'prompts.all_tiers'))}</option>
+          ${(['good', 'ok', 'weak', 'bad'] as const)
+            .map(
+              (tId) =>
+                `<option value="${tId}" ${tierFilter === tId ? 'selected' : ''}>${escapeHtml(t(locale, `tier.${tId === 'good' ? 'good' : tId === 'ok' ? 'ok' : tId === 'weak' ? 'weak' : 'bad'}` as 'tier.good' | 'tier.ok' | 'tier.weak' | 'tier.bad'))}</option>`
+            )
             .join('')}
         </select>
         <select name="source" class="border rounded px-2 py-1 bg-white dark:bg-zinc-800">
-          <option value="">All sources</option>
+          <option value="">${escapeHtml(t(locale, 'prompts.all_sources'))}</option>
           ${sourceOptions
             .map(
               (s) => `<option value="${s}" ${sourceFilter === s ? 'selected' : ''}>${s}</option>`
             )
             .join('')}
         </select>
-        <input name="rule" placeholder="rule id e.g. R003" value="${escapeHtml(ruleFilter ?? '')}"
+        <input name="rule" placeholder="${escapeHtml(t(locale, 'prompts.rule_placeholder'))}" value="${escapeHtml(ruleFilter ?? '')}"
                class="border rounded px-2 py-1 bg-white dark:bg-zinc-800" />
-        <button class="px-3 py-1 bg-blue-600 text-white rounded">Filter</button>
-        <a href="/prompts" class="px-3 py-1 text-gray-500">Clear</a>
+        <button class="px-3 py-1 bg-blue-600 text-white rounded">${escapeHtml(t(locale, 'prompts.filter'))}</button>
+        <a href="/prompts?lang=${locale}" class="px-3 py-1 text-gray-500">${escapeHtml(t(locale, 'prompts.clear'))}</a>
       </form>
       <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-lg shadow overflow-hidden">
         <thead class="bg-gray-100 dark:bg-zinc-700 text-left">
           <tr>
-            <th class="p-2 w-16">Score</th>
-            <th class="p-2 w-20">Tier</th>
-            <th class="p-2 w-24">Source</th>
-            <th class="p-2 w-10">Hits</th>
-            <th class="p-2">Prompt</th>
-            <th class="p-2 w-40">Created</th>
+            <th class="p-2 w-16">${escapeHtml(t(locale, 'prompts.col.score'))}</th>
+            <th class="p-2 w-20">${escapeHtml(t(locale, 'prompts.col.tier'))}</th>
+            <th class="p-2 w-24">${escapeHtml(t(locale, 'prompts.col.source'))}</th>
+            <th class="p-2 w-10">${escapeHtml(t(locale, 'prompts.col.hits'))}</th>
+            <th class="p-2">${escapeHtml(t(locale, 'prompts.col.prompt'))}</th>
+            <th class="p-2 w-40">${escapeHtml(t(locale, 'prompts.col.created'))}</th>
           </tr>
         </thead>
         <tbody>
           ${rows
             .map(
               (r) =>
-                `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}'">
+                `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}?lang=${locale}'">
                    <td class="p-2 font-mono">${r.score >= 0 ? r.score : '-'}</td>
-                   <td class="p-2">${tierBadge(r.tier)}</td>
+                   <td class="p-2">${tierBadge(r.tier, locale)}</td>
                    <td class="p-2 text-xs text-gray-600 dark:text-zinc-300">${escapeHtml(r.source)}</td>
                    <td class="p-2 text-gray-500">${r.hits}</td>
                    <td class="p-2 truncate max-w-[32rem]">${escapeHtml(r.snippet)}</td>
@@ -329,10 +363,17 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
             .join('')}
         </tbody>
       </table>`;
-    reply.type('text/html; charset=utf-8').send(layout('Prompts', body));
+    reply.type('text/html; charset=utf-8').send(
+      layout(t(locale, 'prompts.title'), body, locale, {
+        reqPath: '/prompts',
+        reqQuery: reqQueryPassthrough(req),
+        liveRefresh: true,
+      })
+    );
   });
 
   fastify.get('/prompts/:id', async (req, reply) => {
+    const locale = reqLocale(req);
     const { id } = req.params as { id: string };
     const u = db.prepare(`SELECT * FROM prompt_usages WHERE id=?`).get(id) as
       | {
@@ -347,7 +388,10 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         }
       | undefined;
     if (!u) {
-      reply.code(404).type('text/html').send(layout('Not found', '<p>Not found</p>'));
+      reply
+        .code(404)
+        .type('text/html')
+        .send(layout('Not found', '<p>Not found</p>', locale));
       return;
     }
     const score = db.prepare(`SELECT * FROM quality_scores WHERE usage_id=?`).get(id) as
@@ -371,20 +415,20 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       reason: string | null;
     }>;
     const fb = getOutcomeTotals(db, id);
-    const lang = u.detected_language ?? '?';
+    const detected = u.detected_language ?? '?';
 
     const body = `
-      <div class="mb-3"><a href="/prompts" class="text-blue-600 text-sm">← back</a></div>
-      <h1 class="text-2xl font-bold mb-2">Prompt ${escapeHtml(u.id.slice(-8))}</h1>
+      <div class="mb-3"><a href="/prompts?lang=${locale}" class="text-blue-600 text-sm">${escapeHtml(t(locale, 'common.back'))}</a></div>
+      <h1 class="text-2xl font-bold mb-2">${escapeHtml(t(locale, 'detail.title'))} ${escapeHtml(u.id.slice(-8))}</h1>
       <div class="text-xs text-gray-500 mb-4">
-        session <a class="underline" href="/sessions/${u.session_id}">${escapeHtml(u.session_id)}</a>
-        · ${u.char_len} chars · ${u.word_count} words · turn ${u.turn_index}
-        · <span class="uppercase">${escapeHtml(lang)}</span>
+        ${escapeHtml(t(locale, 'detail.session'))} <a class="underline" href="/sessions/${u.session_id}?lang=${locale}">${escapeHtml(u.session_id)}</a>
+        · ${u.char_len} ${escapeHtml(t(locale, 'detail.chars'))} · ${u.word_count} ${escapeHtml(t(locale, 'detail.words'))} · ${escapeHtml(t(locale, 'detail.turn'))} ${u.turn_index}
+        · <span class="uppercase">${escapeHtml(detected)}</span>
         · ${escapeHtml(u.created_at)}
       </div>
 
       <div class="mb-4 flex items-center gap-3">
-        <span class="text-xs text-gray-500">Feedback:</span>
+        <span class="text-xs text-gray-500">${escapeHtml(t(locale, 'detail.feedback'))}</span>
         <form method="POST" action="/prompts/${escapeHtml(u.id)}/feedback" style="display:inline">
           <input type="hidden" name="rating" value="up" />
           <button class="px-3 py-1 rounded border border-green-300 bg-green-50 dark:bg-green-900 hover:bg-green-100 text-sm">👍 ${fb.ups}</button>
@@ -393,35 +437,35 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
           <input type="hidden" name="rating" value="down" />
           <button class="px-3 py-1 rounded border border-red-300 bg-red-50 dark:bg-red-900 hover:bg-red-100 text-sm">👎 ${fb.downs}</button>
         </form>
-        <span class="text-xs text-gray-400">(reprocess after session end to update usage_score)</span>
+        <span class="text-xs text-gray-400">${escapeHtml(t(locale, 'detail.reprocess_hint'))}</span>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div class="md:col-span-2 bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
-          <div class="text-xs text-gray-500 mb-2">Original</div>
+          <div class="text-xs text-gray-500 mb-2">${escapeHtml(t(locale, 'detail.original'))}</div>
           <pre class="text-sm">${escapeHtml(u.prompt_text)}</pre>
         </div>
         <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
-          <div class="text-xs text-gray-500 mb-3">Score</div>
+          <div class="text-xs text-gray-500 mb-3">${escapeHtml(t(locale, 'detail.score'))}</div>
           ${
             score
               ? `<div class="text-4xl font-mono mb-3">${score.final_score}</div>
-                 <div class="mb-3">${tierBadge(score.tier)}</div>
+                 <div class="mb-3">${tierBadge(score.tier, locale)}</div>
                  <div class="text-xs space-y-1 text-gray-600 dark:text-zinc-300">
                    <div>rule: ${score.rule_score}</div>
                    <div>usage: ${score.usage_score ?? '-'}</div>
                    <div>judge: ${score.judge_score ?? '-'}</div>
                  </div>`
-              : '<div class="text-sm text-gray-400">no score yet</div>'
+              : `<div class="text-sm text-gray-400">${escapeHtml(t(locale, 'common.no_data'))}</div>`
           }
         </div>
       </div>
 
-      <h2 class="font-bold mb-2">Rule hits</h2>
+      <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'detail.rule_hits'))}</h2>
       <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
         ${
           hits.length === 0
-            ? '<div class="p-3 text-sm text-gray-400">(no hits)</div>'
+            ? `<div class="p-3 text-sm text-gray-400">${escapeHtml(t(locale, 'detail.no_hits'))}</div>`
             : hits
                 .map(
                   (h) =>
@@ -435,13 +479,11 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         }
       </div>
 
-      <h2 class="font-bold mb-2">Suggested rewrites</h2>
+      <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'detail.suggested_rewrites'))}</h2>
       <div class="space-y-3">
         ${
           rewrites.length === 0
-            ? '<div class="text-sm text-gray-400">(none) — try: <code>think-prompt rewrite ' +
-              escapeHtml(u.id) +
-              '</code></div>'
+            ? `<div class="text-sm text-gray-400">${escapeHtml(t(locale, 'detail.rewrite_none'))}<code>think-prompt rewrite ${escapeHtml(u.id)}</code></div>`
             : rewrites
                 .map(
                   (r) =>
@@ -454,16 +496,25 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                 .join('')
         }
       </div>`;
-    reply.type('text/html; charset=utf-8').send(layout('Prompt', body));
+    reply.type('text/html; charset=utf-8').send(
+      layout(t(locale, 'detail.title'), body, locale, {
+        reqPath: `/prompts/${u.id}`,
+        reqQuery: reqQueryPassthrough(req),
+      })
+    );
   });
 
   fastify.get('/sessions/:id', async (req, reply) => {
+    const locale = reqLocale(req);
     const { id } = req.params as { id: string };
     const session = db.prepare(`SELECT * FROM sessions WHERE id=?`).get(id) as
       | { cwd: string; model: string | null; started_at: string }
       | undefined;
     if (!session) {
-      reply.code(404).type('text/html').send(layout('Not found', '<p>Not found</p>'));
+      reply
+        .code(404)
+        .type('text/html')
+        .send(layout('Not found', '<p>Not found</p>', locale));
       return;
     }
     const usages = db
@@ -500,77 +551,95 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       total_ms: number;
     }>;
     const body = `
-      <h1 class="text-2xl font-bold mb-2">Session ${escapeHtml(id.slice(-8))}</h1>
+      <h1 class="text-2xl font-bold mb-2">${escapeHtml(t(locale, 'session.title'))} ${escapeHtml(id.slice(-8))}</h1>
       <div class="text-xs text-gray-500 mb-4">
         cwd: ${escapeHtml(session.cwd)} · model: ${escapeHtml(session.model ?? '-')} · started ${escapeHtml(session.started_at)}
       </div>
 
-      <h2 class="font-bold mb-2">Turns</h2>
+      <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'session.turns'))}</h2>
       <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
         ${usages
           .map(
             (u) =>
-              `<a href="/prompts/${u.id}" class="flex items-center gap-3 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
+              `<a href="/prompts/${u.id}?lang=${locale}" class="flex items-center gap-3 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
                  <span class="text-xs text-gray-400 w-8">#${u.turn_index}</span>
                  <span class="font-mono text-sm w-10 text-right">${u.score >= 0 ? u.score : '-'}</span>
-                 ${tierBadge(u.tier)}
+                 ${tierBadge(u.tier, locale)}
                  <span class="flex-1 truncate text-sm">${escapeHtml(u.snippet)}</span>
                </a>`
           )
           .join('')}
       </div>
 
-      <h2 class="font-bold mb-2">Subagents (${subs.length})</h2>
+      <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'session.subagents'))} (${subs.length})</h2>
       <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
         ${
           subs.length === 0
-            ? '<div class="p-3 text-sm text-gray-400">none</div>'
+            ? `<div class="p-3 text-sm text-gray-400">${escapeHtml(t(locale, 'session.none'))}</div>`
             : subs
                 .map(
                   (s) =>
                     `<div class="p-3">
                        <div class="text-sm font-semibold">${escapeHtml(s.agent_type)} · <span class="text-gray-400 text-xs">${escapeHtml(s.agent_id)}</span></div>
                        <div class="text-xs text-gray-500 mt-1">${escapeHtml(s.status)}</div>
-                       ${s.prompt_text ? `<div class="mt-2 text-xs text-gray-600"><span class="font-semibold">prompt:</span> ${escapeHtml(s.prompt_text.slice(0, 200))}</div>` : ''}
+                       ${s.prompt_text ? `<div class="mt-2 text-xs text-gray-600"><span class="font-semibold">${escapeHtml(t(locale, 'session.prompt'))}</span> ${escapeHtml(s.prompt_text.slice(0, 200))}</div>` : ''}
                      </div>`
                 )
                 .join('')
         }
       </div>
 
-      <h2 class="font-bold mb-2">Tool use rollup</h2>
+      <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'session.tool_rollup'))}</h2>
       <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-lg shadow overflow-hidden">
         <thead class="bg-gray-100 dark:bg-zinc-700 text-left">
-          <tr><th class="p-2">Tool</th><th class="p-2">Calls</th><th class="p-2">Fails</th><th class="p-2">Total ms</th></tr>
+          <tr>
+            <th class="p-2">${escapeHtml(t(locale, 'session.col.tool'))}</th>
+            <th class="p-2">${escapeHtml(t(locale, 'session.col.calls'))}</th>
+            <th class="p-2">${escapeHtml(t(locale, 'session.col.fails'))}</th>
+            <th class="p-2">${escapeHtml(t(locale, 'session.col.ms'))}</th>
+          </tr>
         </thead>
         <tbody>
           ${tools
             .map(
-              (t) =>
+              (toolRow) =>
                 `<tr class="border-t border-gray-100 dark:border-zinc-700">
-                   <td class="p-2 font-mono">${escapeHtml(t.tool_name)}</td>
-                   <td class="p-2">${t.call_count}</td>
-                   <td class="p-2 ${t.fail_count > 0 ? 'text-red-600' : ''}">${t.fail_count}</td>
-                   <td class="p-2 text-gray-500">${t.total_ms}</td>
+                   <td class="p-2 font-mono">${escapeHtml(toolRow.tool_name)}</td>
+                   <td class="p-2">${toolRow.call_count}</td>
+                   <td class="p-2 ${toolRow.fail_count > 0 ? 'text-red-600' : ''}">${toolRow.fail_count}</td>
+                   <td class="p-2 text-gray-500">${toolRow.total_ms}</td>
                  </tr>`
             )
             .join('')}
         </tbody>
       </table>`;
-    reply.type('text/html; charset=utf-8').send(layout('Session', body));
+    reply.type('text/html; charset=utf-8').send(
+      layout(t(locale, 'session.title'), body, locale, {
+        reqPath: `/sessions/${id}`,
+        reqQuery: reqQueryPassthrough(req),
+      })
+    );
   });
 
-  fastify.get('/rules', async (_req, reply) => {
+  fastify.get('/rules', async (req, reply) => {
+    const locale = reqLocale(req);
     const catalog = getRulesCatalog();
     const hitStats = db
       .prepare(`SELECT rule_id, COUNT(*) AS c FROM rule_hits GROUP BY rule_id`)
       .all() as Array<{ rule_id: string; c: number }>;
     const hitMap = Object.fromEntries(hitStats.map((h) => [h.rule_id, h.c]));
     const body = `
-      <h1 class="text-2xl font-bold mb-4">Rule catalog</h1>
+      <h1 class="text-2xl font-bold mb-4">${escapeHtml(t(locale, 'rules.title'))}</h1>
       <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-lg shadow overflow-hidden">
         <thead class="bg-gray-100 dark:bg-zinc-700 text-left">
-          <tr><th class="p-2 w-16">ID</th><th class="p-2">Name</th><th class="p-2 w-24">Category</th><th class="p-2 w-16">Sev</th><th class="p-2 w-16">Hits</th><th class="p-2">Description</th></tr>
+          <tr>
+            <th class="p-2 w-16">${escapeHtml(t(locale, 'rules.col.id'))}</th>
+            <th class="p-2">${escapeHtml(t(locale, 'rules.col.name'))}</th>
+            <th class="p-2 w-24">${escapeHtml(t(locale, 'rules.col.category'))}</th>
+            <th class="p-2 w-16">${escapeHtml(t(locale, 'rules.col.sev'))}</th>
+            <th class="p-2 w-16">${escapeHtml(t(locale, 'rules.col.hits'))}</th>
+            <th class="p-2">${escapeHtml(t(locale, 'rules.col.description'))}</th>
+          </tr>
         </thead>
         <tbody>
         ${catalog
@@ -588,26 +657,35 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
           .join('')}
         </tbody>
       </table>`;
-    reply.type('text/html; charset=utf-8').send(layout('Rules', body));
+    reply.type('text/html; charset=utf-8').send(
+      layout(t(locale, 'rules.title'), body, locale, {
+        reqPath: '/rules',
+        reqQuery: reqQueryPassthrough(req),
+      })
+    );
   });
 
-  fastify.get('/settings', async (_req, reply) => {
+  fastify.get('/settings', async (req, reply) => {
+    const locale = reqLocale(req);
     const body = `
-      <h1 class="text-2xl font-bold mb-4">Settings</h1>
-      <p class="text-sm text-gray-600 dark:text-zinc-300 mb-4">
-        Edit <code>~/.think-prompt/config.json</code> or use the CLI:
-      </p>
+      <h1 class="text-2xl font-bold mb-4">${escapeHtml(t(locale, 'settings.title'))}</h1>
+      <p class="text-sm text-gray-600 dark:text-zinc-300 mb-4">${escapeHtml(t(locale, 'settings.edit_hint'))}</p>
       <pre class="bg-gray-100 dark:bg-zinc-800 rounded p-4 text-sm">think-prompt config list
 think-prompt config set agent.coach_mode true
 think-prompt config set llm.enabled true
 think-prompt coach on</pre>
-      <h2 class="font-bold mt-6 mb-2">Current config (read-only)</h2>
+      <h2 class="font-bold mt-6 mb-2">${escapeHtml(t(locale, 'settings.config_readonly'))}</h2>
       <pre class="bg-gray-100 dark:bg-zinc-800 rounded p-4 text-xs overflow-auto">${escapeHtml(JSON.stringify(config, null, 2))}</pre>`;
-    reply.type('text/html; charset=utf-8').send(layout('Settings', body));
+    reply.type('text/html; charset=utf-8').send(
+      layout(t(locale, 'settings.title'), body, locale, {
+        reqPath: '/settings',
+        reqQuery: reqQueryPassthrough(req),
+      })
+    );
   });
 
-  fastify.get('/doctor', async (_req, reply) => {
-    // Simple doctor-like view
+  fastify.get('/doctor', async (req, reply) => {
+    const locale = reqLocale(req);
     const agentPid = db.prepare(`SELECT value FROM _meta WHERE key='installed_at'`).get() as
       | { value: string }
       | undefined;
@@ -628,9 +706,9 @@ think-prompt coach on</pre>
       rewrites: number;
     };
     const body = `
-      <h1 class="text-2xl font-bold mb-4">Doctor</h1>
+      <h1 class="text-2xl font-bold mb-4">${escapeHtml(t(locale, 'doctor.title'))}</h1>
       <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4 mb-4">
-        <h2 class="font-bold mb-2">Counts</h2>
+        <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'doctor.counts'))}</h2>
         <ul class="text-sm space-y-1">
           <li>prompt_usages: ${counts.usages}</li>
           <li>sessions: ${counts.sessions}</li>
@@ -640,10 +718,15 @@ think-prompt coach on</pre>
         </ul>
       </div>
       <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
-        <h2 class="font-bold mb-2">Installed</h2>
+        <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'doctor.installed'))}</h2>
         <p class="text-sm text-gray-500">${escapeHtml(agentPid?.value ?? 'unknown')}</p>
       </div>`;
-    reply.type('text/html; charset=utf-8').send(layout('Doctor', body));
+    reply.type('text/html; charset=utf-8').send(
+      layout(t(locale, 'doctor.title'), body, locale, {
+        reqPath: '/doctor',
+        reqQuery: reqQueryPassthrough(req),
+      })
+    );
   });
 
   // POST /prompts/:id/feedback — form-encoded {rating: up|down, note?}
@@ -666,7 +749,6 @@ think-prompt coach on</pre>
       return;
     }
     recordOutcome(db, id, rating, body.note ?? null);
-    // Redirect back to the detail page
     reply.redirect(`/prompts/${id}`);
   });
 

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe('dashboard', () => {
-  it('renders overview with data', async () => {
+  it('renders overview with data (English locale)', async () => {
     const db = openDb();
     upsertSession(db, { id: 's1', cwd: '/tmp' });
     const u = insertPromptUsage(db, { session_id: 's1', prompt_text: 'hello world' });
@@ -33,10 +33,13 @@ describe('dashboard', () => {
     db.close();
 
     const app = buildDashboardServer({ rootOverride: tmp });
-    const res = await app.inject({ method: 'GET', url: '/' });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('Overview');
     expect(res.body).toContain('Total prompts');
+    // Live-refresh bootstrap is injected on the overview.
+    expect(res.body).toContain('data-latest-id');
+    expect(res.body).toContain('/api/overview/latest-id');
     await app.close();
   });
 
@@ -54,24 +57,23 @@ describe('dashboard', () => {
     db.close();
 
     const app = buildDashboardServer({ rootOverride: tmp });
-    const res = await app.inject({ method: 'GET', url: `/prompts/${u.id}` });
+    const res = await app.inject({ method: 'GET', url: `/prompts/${u.id}?lang=en` });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('Prompt');
     expect(res.body).toContain('fix');
     await app.close();
   });
 
-  it('renders rules catalog', async () => {
+  it('renders rules catalog (English)', async () => {
     const app = buildDashboardServer({ rootOverride: tmp });
-    const res = await app.inject({ method: 'GET', url: '/rules' });
+    const res = await app.inject({ method: 'GET', url: '/rules?lang=en' });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('Rule catalog');
     expect(res.body).toContain('R001');
     await app.close();
   });
 
-  it('overview shows all 4 tiers (good/ok/weak/bad) even when counts are 0', async () => {
-    // Seed one 'ok' prompt — other tiers should still render as 0, not be hidden.
+  it('overview shows all 5 tier slots (good/ok/weak/bad/n/a) with English labels', async () => {
     const db = openDb();
     upsertSession(db, { id: 's-tiers', cwd: '/tmp' });
     const u = insertPromptUsage(db, { session_id: 's-tiers', prompt_text: 'hello' });
@@ -85,20 +87,19 @@ describe('dashboard', () => {
     db.close();
 
     const app = buildDashboardServer({ rootOverride: tmp });
-    const res = await app.inject({ method: 'GET', url: '/' });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
     expect(res.statusCode).toBe(200);
-    // All 4 tier labels must appear in the breakdown, plus the 'n/a' (unscored).
     for (const tier of ['good', 'ok', 'weak', 'bad', 'n/a']) {
       expect(res.body).toContain(`>${tier}<`);
     }
-    // Total line is exposed.
     expect(res.body).toContain('Tier breakdown');
-    // Coach mode card must NOT be rendered on the overview anymore.
+    // Coach mode card is permanently removed from Overview (was previously
+    // a 3rd tile).
     expect(res.body).not.toContain('Coach mode');
     await app.close();
   });
 
-  it('overview renders the daily stacked-bar chart (SVG)', async () => {
+  it('overview renders the stacked-bar chart without the per-day text list', async () => {
     const db = openDb();
     upsertSession(db, { id: 's-chart', cwd: '/tmp' });
     const u = insertPromptUsage(db, { session_id: 's-chart', prompt_text: 'hi' });
@@ -112,12 +113,28 @@ describe('dashboard', () => {
     db.close();
 
     const app = buildDashboardServer({ rootOverride: tmp });
-    const res = await app.inject({ method: 'GET', url: '/' });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
     expect(res.statusCode).toBe(200);
-    // SVG container is present.
     expect(res.body).toMatch(/<svg[\s\S]*?viewBox/);
-    // Heading + window total line.
     expect(res.body).toContain('Daily additions');
+    // Per-day text list (e.g. "2026-04-10") was removed at user request —
+    // the chart stands alone now. Chart still renders day labels internally
+    // via MM/DD format, but the long "<date> · <counts>" rows are gone.
+    expect(res.body).not.toContain('border-b border-gray-100 dark:border-zinc-700 last:border-0');
+    await app.close();
+  });
+
+  it('live-refresh API returns the latest prompt id', async () => {
+    const db = openDb();
+    upsertSession(db, { id: 's-live', cwd: '/tmp' });
+    const u = insertPromptUsage(db, { session_id: 's-live', prompt_text: 'check' });
+    db.close();
+
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/api/overview/latest-id' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { latestId: string | null };
+    expect(body.latestId).toBe(u.id);
     await app.close();
   });
 
@@ -146,6 +163,76 @@ describe('dashboard', () => {
   });
 });
 
+describe('dashboard i18n', () => {
+  it('serves Korean chrome when ?lang=ko', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=ko' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('개요');
+    expect(res.body).toContain('전체 프롬프트');
+    expect(res.body).toContain('등급 분포');
+    expect(res.body).toContain('<html lang="ko">');
+    await app.close();
+  });
+
+  it('serves Chinese chrome when ?lang=zh', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=zh' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('概览');
+    expect(res.body).toContain('提示总数');
+    expect(res.body).toContain('等级分布');
+    expect(res.body).toContain('<html lang="zh">');
+    await app.close();
+  });
+
+  it('serves Spanish chrome when ?lang=es', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=es' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('Resumen');
+    expect(res.body).toContain('Total de prompts');
+    expect(res.body).toContain('Distribución por nivel');
+    expect(res.body).toContain('<html lang="es">');
+    await app.close();
+  });
+
+  it('serves Japanese chrome when ?lang=ja', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=ja' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('概要');
+    expect(res.body).toContain('プロンプト総数');
+    expect(res.body).toContain('品質レベル分布');
+    expect(res.body).toContain('<html lang="ja">');
+    await app.close();
+  });
+
+  it('honours Accept-Language header when no ?lang= override', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: { 'accept-language': 'es-ES,es;q=0.9,en;q=0.8' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('Resumen');
+    await app.close();
+  });
+
+  it('renders a language switcher with all 5 locales', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('English');
+    expect(res.body).toContain('한국어');
+    expect(res.body).toContain('中文');
+    expect(res.body).toContain('Español');
+    expect(res.body).toContain('日本語');
+    await app.close();
+  });
+});
+
 describe('renderDailyChart', () => {
   const zeroDay = (
     day: string
@@ -167,9 +254,7 @@ describe('renderDailyChart', () => {
     const svg = renderDailyChart(data);
     expect(svg).toContain('<svg');
     expect(svg).toContain('viewBox');
-    // Gridline labels exist (niceCeil(3) = 5).
     expect(svg).toMatch(/<text[^>]*>5<\/text>/);
-    // Legend labels for ALL 5 statuses.
     for (const label of ['good', 'ok', 'weak', 'bad', 'n/a']) {
       expect(svg).toContain(`>${label}<`);
     }
@@ -188,11 +273,11 @@ describe('renderDailyChart', () => {
   it('colors segments by tier with the expected palette', () => {
     const data = [{ ...zeroDay('2026-04-10'), good: 1, ok: 1, weak: 1, bad: 1, na: 1, total: 5 }];
     const svg = renderDailyChart(data);
-    expect(svg).toContain('fill="#22c55e"'); // good  (green)
-    expect(svg).toContain('fill="#eab308"'); // ok    (yellow)
-    expect(svg).toContain('fill="#f97316"'); // weak  (orange)
-    expect(svg).toContain('fill="#ef4444"'); // bad   (red)
-    expect(svg).toContain('fill="#9ca3af"'); // n/a   (gray)
+    expect(svg).toContain('fill="#22c55e"');
+    expect(svg).toContain('fill="#eab308"');
+    expect(svg).toContain('fill="#f97316"');
+    expect(svg).toContain('fill="#ef4444"');
+    expect(svg).toContain('fill="#9ca3af"');
   });
 
   it('handles empty data (no rows) without throwing', () => {


### PR DESCRIPTION
## Summary / 요약

PR #17로 도입된 `i18n.ts` 스캐폴딩을 실제 대시보드 라우트에 연결. 5개 언어(en/ko/zh/es/ja) UI 크롬, 언어 스위처, 자동 새로고침, 차트 아래 일별 텍스트 리스트 제거를 한 PR로 번들.

Wires up the i18n scaffolding from PR #17 into every dashboard route and bundles two companion UX fixes: remove the per-day text list below the Overview chart, and add a 6-second polling auto-refresh.

## Locale resolution / 로케일 우선순위

1. `?lang=xx` query override
2. `Accept-Language` header (first supported)
3. `config.i18n` (persisted user preference)
4. `'en'` fallback

사용자 입력(프롬프트 본문, 세션 ID, 타임스탬프, 룰 ID)은 **원문 그대로** 유지, UI 크롬만 번역.

## What was translated

| Area | Coverage |
|---|---|
| Navigation (Overview / Prompts / Rules / Settings / Doctor) | ✅ |
| Overview: total prompts, tier breakdown, daily additions, lowest, recent | ✅ |
| Prompts list: filters, column headers, empty state | ✅ |
| Prompt detail: section headers, feedback label, empty states | ✅ |
| Session detail: turns / subagents / tool-rollup headers and columns | ✅ |
| Rules: title + column headers | ✅ |
| Settings / Doctor: titles and section headers | ✅ |
| Tier badges: `good / ok / weak / bad / n/a` → translated display labels | ✅ |

## What was NOT translated (intentional)

- User prompt text
- Session IDs, rule IDs (R001 …), timestamps
- Rule names / descriptions from `@think-prompt/rules` (would require translating the rules registry — separate PR)

## Bundled UX fixes / 함께 반영된 UX 수정

1. **Chart-only Daily additions panel** — removed the per-day date/count text list that was sitting below the bar chart; the chart carries the daily view on its own now.
2. **Live-refresh polling** — layout injects a 6s poller that checks `GET /api/overview/latest-id`; on watermark change, the tab reloads. Applied to Overview + Prompts list only (detail pages opt out to preserve scroll state).

## Test plan / 테스트 계획

- [x] `pnpm typecheck` — 7/7 packages clean
- [x] `pnpm lint` — biome clean on all changed files
- [x] `pnpm test` — **167/167 passing** (was 155; +12 i18n coverage + live-refresh API)
- [ ] Manual spot-check of `?lang=ko/zh/es/ja` in browser
- [ ] Verify 6-second auto-refresh triggers on new prompt arrival

## Out of scope (discussed separately)

- Historical backfill from `~/.claude/projects/**/history.jsonl` — D-019 Phase 2
- Storage retention changes — already configurable via `privacy.retention_days`
- Server-side anonymous telemetry — blocked by D-004 and D-030, requires a superseding decision before implementation

Refs: D-012 (dashboard UI stack), D-004 (local-first), D-030 (no telemetry)