### PR TITLE
feat(dashboard): 14일 차트 / 90일 보존 기본 제한 제거 + 기간 선택기 / Remove 14-day chart and 90-day retention defaults, add period selector

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -23,7 +23,10 @@ export const ConfigSchema = z.object({
     .object({
       store_original: z.boolean().default(true),
       pii_mask: z.boolean().default(true),
-      retention_days: z.number().default(90),
+      // 0 = keep forever (no retention limit). Positive N = purge records
+      // older than N days when a cleanup job runs (none ships today — this
+      // field is declarative until a retention worker is added).
+      retention_days: z.number().default(0),
       sync_to_server: z.boolean().default(false),
     })
     .default({}),

--- a/packages/dashboard/src/i18n.ts
+++ b/packages/dashboard/src/i18n.ts
@@ -42,6 +42,7 @@ export interface Dictionary {
   'common.no_data': string;
   'common.none': string;
   'common.language': string;
+  'common.all': string;
 
   /* overview */
   'overview.title': string;
@@ -133,6 +134,7 @@ const EN: Dictionary = {
   'common.no_data': 'no data',
   'common.none': '(none)',
   'common.language': 'Language',
+  'common.all': 'all',
 
   'overview.title': 'Overview',
   'overview.total_prompts': 'Total prompts',
@@ -216,6 +218,7 @@ const KO: Dictionary = {
   'common.no_data': '데이터 없음',
   'common.none': '(없음)',
   'common.language': '언어',
+  'common.all': '전체',
 
   'overview.title': '개요',
   'overview.total_prompts': '전체 프롬프트',
@@ -299,6 +302,7 @@ const ZH: Dictionary = {
   'common.no_data': '暂无数据',
   'common.none': '(无)',
   'common.language': '语言',
+  'common.all': '全部',
 
   'overview.title': '概览',
   'overview.total_prompts': '提示总数',
@@ -382,6 +386,7 @@ const ES: Dictionary = {
   'common.no_data': 'sin datos',
   'common.none': '(ninguno)',
   'common.language': 'Idioma',
+  'common.all': 'todo',
 
   'overview.title': 'Resumen',
   'overview.total_prompts': 'Total de prompts',
@@ -465,6 +470,7 @@ const JA: Dictionary = {
   'common.no_data': 'データなし',
   'common.none': '(なし)',
   'common.language': '言語',
+  'common.all': 'すべて',
 
   'overview.title': '概要',
   'overview.total_prompts': 'プロンプト総数',

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -102,8 +102,34 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     }));
     const tierTotal = tierCounts.reduce((acc, r) => acc + r.c, 0);
 
-    // Daily tier breakdown for the last N days.
-    const DAYS = 14;
+    // Daily tier breakdown — window size driven by ?days=.
+    // Accepted: 7, 14, 30, 90, 365, "all". Default 30. Anything else -> 30.
+    // "all" walks back to the earliest prompt (capped at 730 days to keep
+    // the chart SVG from getting absurdly wide on very old installs).
+    const daysParam = (() => {
+      const q = (req.query as Record<string, unknown> | null | undefined) ?? {};
+      const raw = typeof q.days === 'string' ? q.days.toLowerCase() : undefined;
+      if (raw === 'all') return 'all' as const;
+      const n = raw ? Number.parseInt(raw, 10) : Number.NaN;
+      return [7, 14, 30, 90, 365].includes(n) ? n : 30;
+    })();
+
+    // Resolve the actual window length in days.
+    let DAYS: number;
+    if (daysParam === 'all') {
+      const earliest = db.prepare(`SELECT DATE(MIN(created_at)) AS d FROM prompt_usages`).get() as {
+        d: string | null;
+      };
+      if (earliest?.d) {
+        const ms = Date.now() - new Date(`${earliest.d}T00:00:00Z`).getTime();
+        DAYS = Math.min(730, Math.max(1, Math.ceil(ms / 86400000) + 1));
+      } else {
+        DAYS = 14; // No data — show an empty 14-day frame.
+      }
+    } else {
+      DAYS = daysParam;
+    }
+
     const dailyRows = db
       .prepare(
         `SELECT DATE(pu.created_at) AS day,
@@ -150,6 +176,26 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       days.push(row);
     }
     const windowTotal = days.reduce((a, d) => a + d.total, 0);
+
+    // Period selector options for the header pill bar.
+    const PERIOD_OPTIONS: Array<{ value: string; label: string }> = [
+      { value: '7', label: '7d' },
+      { value: '14', label: '14d' },
+      { value: '30', label: '30d' },
+      { value: '90', label: '90d' },
+      { value: '365', label: '365d' },
+      { value: 'all', label: t(locale, 'common.all') },
+    ];
+    const selectedPeriod = daysParam === 'all' ? 'all' : String(daysParam);
+    const periodHtml = PERIOD_OPTIONS.map(({ value, label }) => {
+      const href = `/?lang=${locale}&days=${encodeURIComponent(value)}`;
+      const active = value === selectedPeriod;
+      const base = 'px-2 py-1 text-xs rounded border transition-colors';
+      const activeCls = 'bg-blue-600 text-white border-blue-600';
+      const inactiveCls =
+        'bg-white dark:bg-zinc-800 text-gray-600 dark:text-zinc-300 border-gray-300 dark:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-700';
+      return `<a href="${href}" class="${base} ${active ? activeCls : inactiveCls}">${escapeHtml(label)}</a>`;
+    }).join('');
 
     const recent = db
       .prepare(
@@ -202,9 +248,12 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       </div>
 
       <section class="mb-8">
-        <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
           <h2 class="text-lg font-bold">${escapeHtml(t(locale, 'overview.daily_additions', { n: DAYS }))}</h2>
-          <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'common.total'))} <span class="font-mono">${windowTotal}</span></div>
+          <div class="flex items-center gap-3 flex-wrap">
+            <div class="flex items-center gap-1">${periodHtml}</div>
+            <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'common.total'))} <span class="font-mono">${windowTotal}</span></div>
+          </div>
         </div>
         <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
           ${chartHtml}

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -169,12 +169,8 @@ describe('dashboard period selector (?days=)', () => {
     const res = await app.inject({ method: 'GET', url: '/?lang=en' });
     expect(res.statusCode).toBe(200);
     // The 30d pill should be the one marked active (blue bg), 7d should be inactive.
-    expect(res.body).toMatch(
-      /<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/
-    );
-    expect(res.body).not.toMatch(
-      /<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/
-    );
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/);
+    expect(res.body).not.toMatch(/<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/);
     await app.close();
   });
 
@@ -182,9 +178,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=7' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(
-      /<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/
-    );
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/);
     await app.close();
   });
 
@@ -192,9 +186,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=90' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(
-      /<a href="\/\?lang=en&days=90"[^>]*bg-blue-600[^>]*>90d<\/a>/
-    );
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=90"[^>]*bg-blue-600[^>]*>90d<\/a>/);
     await app.close();
   });
 
@@ -202,9 +194,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=365' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(
-      /<a href="\/\?lang=en&days=365"[^>]*bg-blue-600[^>]*>365d<\/a>/
-    );
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=365"[^>]*bg-blue-600[^>]*>365d<\/a>/);
     await app.close();
   });
 
@@ -217,9 +207,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=all' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(
-      /<a href="\/\?lang=en&days=all"[^>]*bg-blue-600[^>]*>all<\/a>/
-    );
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=all"[^>]*bg-blue-600[^>]*>all<\/a>/);
     await app.close();
   });
 
@@ -230,9 +218,7 @@ describe('dashboard period selector (?days=)', () => {
       url: '/?lang=en&days=not-a-number',
     });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(
-      /<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/
-    );
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/);
     await app.close();
   });
 

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -163,6 +163,101 @@ describe('dashboard', () => {
   });
 });
 
+describe('dashboard period selector (?days=)', () => {
+  it('defaults to 30 days when ?days= is missing', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.statusCode).toBe(200);
+    // The 30d pill should be the one marked active (blue bg), 7d should be inactive.
+    expect(res.body).toMatch(
+      /<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/
+    );
+    expect(res.body).not.toMatch(
+      /<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/
+    );
+    await app.close();
+  });
+
+  it('honours ?days=7 by marking the 7d pill active', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en&days=7' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(
+      /<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/
+    );
+    await app.close();
+  });
+
+  it('accepts ?days=90 as a valid window', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en&days=90' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(
+      /<a href="\/\?lang=en&days=90"[^>]*bg-blue-600[^>]*>90d<\/a>/
+    );
+    await app.close();
+  });
+
+  it('accepts ?days=365 as a valid window', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en&days=365' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(
+      /<a href="\/\?lang=en&days=365"[^>]*bg-blue-600[^>]*>365d<\/a>/
+    );
+    await app.close();
+  });
+
+  it('accepts ?days=all and caps the window to available data', async () => {
+    const db = openDb();
+    upsertSession(db, { id: 's-all', cwd: '/tmp' });
+    insertPromptUsage(db, { session_id: 's-all', prompt_text: 'ancient' });
+    db.close();
+
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en&days=all' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(
+      /<a href="\/\?lang=en&days=all"[^>]*bg-blue-600[^>]*>all<\/a>/
+    );
+    await app.close();
+  });
+
+  it('falls back to 30 days when ?days= is garbage', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/?lang=en&days=not-a-number',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(
+      /<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/
+    );
+    await app.close();
+  });
+
+  it('renders all six period options', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('>7d<');
+    expect(res.body).toContain('>14d<');
+    expect(res.body).toContain('>30d<');
+    expect(res.body).toContain('>90d<');
+    expect(res.body).toContain('>365d<');
+    expect(res.body).toContain('>all<');
+    await app.close();
+  });
+
+  it('translates the "all" pill in Korean', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=ko&days=all' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('>전체<');
+    await app.close();
+  });
+});
+
 describe('dashboard i18n', () => {
   it('serves Korean chrome when ?lang=ko', async () => {
     const app = buildDashboardServer({ rootOverride: tmp });


### PR DESCRIPTION
## Summary / 요약

사용자 요청(3개 중 PR A)으로 대시보드의 하드 리밋을 제거.

First of three PRs addressing the user's request to remove built-in limits. This one ships the config-level retention change + Overview period selector.

## Changes / 변경

1. **`privacy.retention_days`: 90 → 0 (unlimited)**
   - 기존 유저는 영향 없음 (config.json 값이 존재하면 그 값 사용)
   - 신규 설치만 무제한으로 시작
   - 클린업 워커는 현재 미존재 — 값은 declarative

2. **Overview 차트 기간: `const DAYS = 14` → `?days=` 쿼리 파라미터**
   - 허용 값: `7 | 14 | 30 | 90 | 365 | all`
   - 기본값: **30** (이전 14 → 상향)
   - `all`: 가장 오래된 프롬프트부터, 730일 상한
   - Invalid 값은 30으로 폴백

3. **Overview 헤더에 기간 pill 버튼 6개 추가**
   - 현재 선택된 기간이 파란색 강조
   - 클릭 시 URL 갱신 (language preference 유지)

4. **i18n `common.all` 키 5개 언어 추가**
   - en: all · ko: 전체 · zh: 全部 · es: todo · ja: すべて

## Test plan / 테스트 계획

- [x] `pnpm typecheck` — 7/7 packages clean
- [x] `pnpm lint` — biome clean
- [x] `pnpm test` — **175/175 passing** (+8 period selector tests)
- [ ] Manual: open dashboard, click each pill, verify chart updates and URL updates

## Scope / 범위

**Included:**
- Retention default change
- Chart period selector with 6 options
- i18n for "all" in 5 languages
- Period selector tests

**NOT included (PR B / PR C):**
- Claude history backfill (`~/.claude/projects/**/*.jsonl` import) — PR B
- Consent-gated deep analysis — PR C
- Retention enforcement worker — future work, separate PR

Refs: D-012 (dashboard UI stack), D-004 (local-first)