### PR TITLE
feat(core,cli): Claude 히스토리 백필 dry-run 스캐너 / Claude history backfill — dry-run scanner

### DIFF
--- a/packages/cli/src/commands/backfill.ts
+++ b/packages/cli/src/commands/backfill.ts
@@ -1,0 +1,111 @@
+/**
+ * `think-prompt backfill` — scan `~/.claude/projects/**\/*.jsonl` and report
+ * how many historical user prompts could be imported.
+ *
+ * This first shipment is DRY-RUN ONLY. `--execute` is deliberately refused
+ * with a clear message so the user sees numbers before committing to a
+ * potentially tens-of-thousands-of-rows import. A follow-up PR will wire
+ * the scanner output into insertPromptUsage + the rules engine.
+ */
+import { openDb, scanClaudeHistory } from '@think-prompt/core';
+import pc from 'picocolors';
+
+export interface BackfillCmdOptions {
+  dryRun?: boolean;
+  execute?: boolean;
+  limit?: string;
+  since?: string;
+  project?: string;
+  root?: string;
+}
+
+export async function backfillCmd(opts: BackfillCmdOptions): Promise<void> {
+  if (opts.execute && !opts.dryRun) {
+    console.log(
+      pc.yellow('⚠') + ' --execute is not wired up yet — this release ships scan-only so you can'
+    );
+    console.log('  preview the counts before a mass import. Run without --execute (or with');
+    console.log('  --dry-run) to see what would be imported; real import lands in a follow-up.');
+    return;
+  }
+
+  const limit = opts.limit ? Number.parseInt(opts.limit, 10) : 0;
+  if (opts.limit && (Number.isNaN(limit) || limit < 0)) {
+    console.log(pc.red('✗') + ` invalid --limit value: ${opts.limit}`);
+    process.exit(2);
+  }
+
+  let db: ReturnType<typeof openDb> | null = null;
+  try {
+    db = openDb();
+  } catch (err) {
+    console.log(
+      pc.yellow('⚠') +
+        ` could not open local DB (${(err as Error).message}); treating everything as new`
+    );
+  }
+
+  const t0 = Date.now();
+  console.log(pc.dim(`scanning ${opts.root ?? '~/.claude/projects'} ...`));
+  const stats = scanClaudeHistory(db, {
+    ...(opts.root ? { root: opts.root } : {}),
+    ...(limit > 0 ? { limit } : {}),
+    ...(opts.since ? { since: opts.since } : {}),
+    ...(opts.project ? { projectFilter: opts.project } : {}),
+  });
+  const ms = Date.now() - t0;
+  if (db) db.close();
+
+  if (!stats.rootExists) {
+    console.log(pc.red('✗') + ` directory not found: ${stats.root}`);
+    console.log('  Claude Code stores session transcripts under ~/.claude/projects/.');
+    console.log(
+      '  If you have never run Claude Code on this machine, there is nothing to backfill.'
+    );
+    process.exit(1);
+    return;
+  }
+
+  console.log('');
+  console.log(pc.bold(`Claude Code history scan  ${pc.dim(`(${ms} ms)`)}`));
+  console.log('');
+  printRow('root', stats.root);
+  printRow('files scanned', stats.filesScanned.toLocaleString());
+  printRow('files with user prompts', stats.filesWithPrompts.toLocaleString());
+  if (stats.filesFailed > 0) {
+    printRow('files failed to parse', pc.yellow(stats.filesFailed.toLocaleString()));
+  }
+  printRow('distinct sessions', stats.distinctSessions.toLocaleString());
+  console.log('');
+  printRow('total user entries', stats.totalUserEntries.toLocaleString());
+  printRow('extractable prompts', stats.extractablePrompts.toLocaleString());
+  if (stats.skippedBySince > 0) {
+    printRow(`skipped by --since ${opts.since}`, stats.skippedBySince.toLocaleString());
+  }
+  console.log('');
+  printRow('already in DB (dedup)', pc.dim(stats.alreadyInDb.toLocaleString()));
+  printRow(
+    'would be imported',
+    stats.newPrompts > 0 ? pc.green(stats.newPrompts.toLocaleString()) : '0'
+  );
+  console.log('');
+  if (stats.earliestTimestamp) {
+    printRow('earliest timestamp', stats.earliestTimestamp);
+    printRow('latest timestamp', stats.latestTimestamp ?? '');
+  }
+  console.log('');
+  console.log(pc.dim('dry-run only — nothing was written.'));
+  if (stats.newPrompts > 0) {
+    console.log(
+      pc.dim(
+        `next step: a future release will add --execute to import these ${stats.newPrompts.toLocaleString()} prompts.`
+      )
+    );
+  }
+}
+
+function printRow(label: string, value: string): void {
+  const pad = 28;
+  const key = label.padEnd(pad);
+  console.log(`  ${pc.dim(key)}${value}`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import {
   autostartEnableCmd,
   autostartStatusCmd,
 } from './commands/autostart.js';
+import { backfillCmd } from './commands/backfill.js';
 import { coachCmd, configGetCmd, configListCmd, configSetCmd } from './commands/config-cmd.js';
 import { restartCmd, startCmd, statusCmd, stopCmd } from './commands/daemon-cmds.js';
 import { doctorCmd } from './commands/doctor.js';
@@ -85,6 +86,17 @@ program
   .action(exportCmd);
 
 program.command('open').description('open local dashboard in browser').action(openCmd);
+
+program
+  .command('backfill')
+  .description('scan ~/.claude/projects for historical prompts (dry-run only for now)')
+  .option('--dry-run', 'preview counts without importing (default)', true)
+  .option('--execute', 'NOT YET IMPLEMENTED — will import in a follow-up release')
+  .option('--limit <n>', 'scan at most N .jsonl files')
+  .option('--since <date>', 'only consider prompts after this date (YYYY-MM-DD)')
+  .option('--project <substr>', 'filter to project dirs containing this substring')
+  .option('--root <path>', 'override the Claude projects directory')
+  .action(backfillCmd);
 
 const autostart = program
   .command('autostart')

--- a/packages/core/src/backfill.ts
+++ b/packages/core/src/backfill.ts
@@ -1,0 +1,324 @@
+import { createHash } from 'node:crypto';
+/**
+ * Claude Code history backfill — scans `~/.claude/projects/**\/*.jsonl` and
+ * reports how many user prompts are there, how many are already present in
+ * the Think-Prompt DB, and how many would be new imports.
+ *
+ * This module is SCAN-ONLY (dry-run). Actual inserts will ship in a
+ * follow-up that wires the scanner to insertPromptUsage.
+ *
+ * Layout observed on macOS:
+ *   ~/.claude/projects/
+ *     -Users-alice-repo/                 ← cwd-encoded path segment
+ *       <session-uuid>.jsonl             ← one session transcript
+ *       <another-uuid>.jsonl
+ *
+ * Schema of a `type: "user"` entry (confirmed from live data):
+ *   {
+ *     type: "user",
+ *     message: { role: "user", content: "<string>" | <content-block-array> },
+ *     sessionId: "<uuid>",
+ *     timestamp: "2026-04-15T11:21:54.972Z",
+ *     cwd: "/Users/alice/repo",
+ *     gitBranch: "main",
+ *     version: "2.1.109",
+ *     ...
+ *   }
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { Database as Db } from 'better-sqlite3';
+
+export interface BackfillScanOptions {
+  /** Override the Claude projects root. Default: `~/.claude/projects`. */
+  root?: string;
+  /** Stop after scanning this many .jsonl files (0 = no limit). */
+  limit?: number;
+  /** Skip prompts older than this ISO date string. */
+  since?: string;
+  /** Only scan sessions whose cwd contains this substring. */
+  projectFilter?: string;
+}
+
+export interface BackfillCandidate {
+  /** Original Claude sessionId (UUID). */
+  sessionId: string;
+  /** Working directory recorded at capture time. */
+  cwd: string;
+  /** ISO timestamp from the JSONL entry. */
+  timestamp: string;
+  /** User prompt text, content array flattened to string if needed. */
+  promptText: string;
+  /** SHA-256 of promptText, hex. Used to dedupe against DB. */
+  promptHash: string;
+  /** File path the candidate came from (for debugging). */
+  sourceFile: string;
+}
+
+export interface BackfillStats {
+  /** Root directory that was scanned. */
+  root: string;
+  /** Whether the root existed. */
+  rootExists: boolean;
+  /** Number of .jsonl files we touched. */
+  filesScanned: number;
+  /** Number of .jsonl files that had at least one user prompt. */
+  filesWithPrompts: number;
+  /** Files we tried to read but could not parse a single entry from. */
+  filesFailed: number;
+  /** Raw count of `type: "user"` entries found. */
+  totalUserEntries: number;
+  /** Entries whose `message.content` yielded a non-empty text. */
+  extractablePrompts: number;
+  /** Prompts whose hash is already present in prompt_usages. */
+  alreadyInDb: number;
+  /** Prompts that would be imported if --execute ran today. */
+  newPrompts: number;
+  /** Prompts skipped because of --since cutoff. */
+  skippedBySince: number;
+  /** Distinct sessionIds observed. */
+  distinctSessions: number;
+  /** Earliest timestamp seen (for the UI "data goes back to …"). */
+  earliestTimestamp: string | null;
+  /** Latest timestamp seen. */
+  latestTimestamp: string | null;
+}
+
+/**
+ * Walk the Claude projects directory and compute import statistics.
+ * Does NOT write to the DB; takes an optional `db` to check for duplicates.
+ */
+export function scanClaudeHistory(db: Db | null, opts: BackfillScanOptions = {}): BackfillStats {
+  const root = opts.root ?? join(homedir(), '.claude', 'projects');
+
+  const stats: BackfillStats = {
+    root,
+    rootExists: existsSync(root),
+    filesScanned: 0,
+    filesWithPrompts: 0,
+    filesFailed: 0,
+    totalUserEntries: 0,
+    extractablePrompts: 0,
+    alreadyInDb: 0,
+    newPrompts: 0,
+    skippedBySince: 0,
+    distinctSessions: 0,
+    earliestTimestamp: null,
+    latestTimestamp: null,
+  };
+
+  if (!stats.rootExists) return stats;
+
+  // Collect .jsonl paths up-front so the caller can reason about totals
+  // before we start streaming. At ~1,000 sessions this is cheap.
+  const files = collectJsonlFiles(root, opts.projectFilter);
+  const cap = opts.limit && opts.limit > 0 ? Math.min(files.length, opts.limit) : files.length;
+
+  // Cache of all prompt_hashes currently in the DB so we do one SELECT not
+  // N SELECTs. O(N) memory but N is our OWN row count, usually small
+  // relative to the history being imported.
+  const hashSet = loadExistingHashes(db);
+
+  const sessionSet = new Set<string>();
+
+  for (let i = 0; i < cap; i++) {
+    const path = files[i];
+    if (!path) continue;
+    stats.filesScanned++;
+
+    const perFile = scanFile(path, opts.since);
+    if (perFile.failed) {
+      stats.filesFailed++;
+      continue;
+    }
+    if (perFile.prompts.length > 0) stats.filesWithPrompts++;
+    stats.totalUserEntries += perFile.userEntries;
+    stats.skippedBySince += perFile.skippedBySince;
+
+    for (const c of perFile.prompts) {
+      stats.extractablePrompts++;
+      sessionSet.add(c.sessionId);
+      if (hashSet.has(c.promptHash)) {
+        stats.alreadyInDb++;
+      } else {
+        stats.newPrompts++;
+      }
+      if (!stats.earliestTimestamp || c.timestamp < stats.earliestTimestamp) {
+        stats.earliestTimestamp = c.timestamp;
+      }
+      if (!stats.latestTimestamp || c.timestamp > stats.latestTimestamp) {
+        stats.latestTimestamp = c.timestamp;
+      }
+    }
+  }
+
+  stats.distinctSessions = sessionSet.size;
+  return stats;
+}
+
+/**
+ * Enumerate one .jsonl at a time so a caller can build a streaming importer
+ * later without re-implementing this walk. Yields relative & absolute paths.
+ */
+export function* iterateClaudeJsonl(
+  root = join(homedir(), '.claude', 'projects')
+): Generator<string> {
+  if (!existsSync(root)) return;
+  for (const p of collectJsonlFiles(root)) yield p;
+}
+
+/**
+ * Parse one JSONL file and return candidates. Exported for tests + the
+ * future --execute path that will feed these into insertPromptUsage.
+ */
+export function parseSessionFile(
+  path: string,
+  since?: string
+): { failed: boolean; userEntries: number; skippedBySince: number; prompts: BackfillCandidate[] } {
+  return scanFile(path, since);
+}
+
+// ---------------- internals ---------------------------------------------
+
+function collectJsonlFiles(root: string, projectFilter?: string): string[] {
+  const out: string[] = [];
+  let projectDirs: string[];
+  try {
+    projectDirs = readdirSync(root).map((d) => join(root, d));
+  } catch {
+    return out;
+  }
+  for (const dir of projectDirs) {
+    let isDir = false;
+    try {
+      isDir = statSync(dir).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    if (projectFilter && !dir.includes(projectFilter)) continue;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (e.endsWith('.jsonl')) out.push(join(dir, e));
+    }
+  }
+  // Deterministic order for testability.
+  out.sort();
+  return out;
+}
+
+function scanFile(
+  path: string,
+  since?: string
+): { failed: boolean; userEntries: number; skippedBySince: number; prompts: BackfillCandidate[] } {
+  const sinceTs = since ? normalizeIsoDate(since) : null;
+  const prompts: BackfillCandidate[] = [];
+  let userEntries = 0;
+  let skippedBySince = 0;
+
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return { failed: true, userEntries: 0, skippedBySince: 0, prompts };
+  }
+
+  // Stream line-by-line so a 50 MB session file doesn't blow memory into
+  // a single giant JSON blob in a retained array. (The file is still
+  // read into memory once — that's unavoidable with synchronous fs.)
+  const lines = text.split('\n');
+  let parsedAny = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(trimmed) as Record<string, unknown>;
+      parsedAny = true;
+    } catch {
+      continue;
+    }
+    if (obj.type !== 'user') continue;
+    userEntries++;
+
+    const timestamp = typeof obj.timestamp === 'string' ? obj.timestamp : undefined;
+    if (!timestamp) continue;
+    if (sinceTs && timestamp < sinceTs) {
+      skippedBySince++;
+      continue;
+    }
+
+    const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId : '';
+    const cwd = typeof obj.cwd === 'string' ? obj.cwd : '';
+    if (!sessionId || !cwd) continue;
+
+    const promptText = extractUserText(obj);
+    if (!promptText) continue;
+
+    prompts.push({
+      sessionId,
+      cwd,
+      timestamp,
+      promptText,
+      promptHash: sha256Hex(promptText),
+      sourceFile: path,
+    });
+  }
+
+  return { failed: !parsedAny, userEntries, skippedBySince, prompts };
+}
+
+function extractUserText(entry: Record<string, unknown>): string | null {
+  const message = (entry.message ?? entry) as Record<string, unknown>;
+  const content = message.content ?? entry.content;
+  if (typeof content === 'string') {
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const item of content) {
+      if (typeof item === 'string') parts.push(item);
+      else if (item && typeof item === 'object') {
+        const t = (item as Record<string, unknown>).text;
+        if (typeof t === 'string') parts.push(t);
+      }
+    }
+    const joined = parts.join('\n').trim();
+    return joined.length > 0 ? joined : null;
+  }
+  return null;
+}
+
+function loadExistingHashes(db: Db | null): Set<string> {
+  const out = new Set<string>();
+  if (!db) return out;
+  try {
+    const rows = db
+      .prepare(`SELECT prompt_hash FROM prompt_usages WHERE prompt_hash IS NOT NULL`)
+      .all() as Array<{ prompt_hash: string | null }>;
+    for (const r of rows) {
+      if (r.prompt_hash) out.add(r.prompt_hash);
+    }
+  } catch {
+    // Schema mismatch or missing table — return empty set and treat
+    // everything as new.
+  }
+  return out;
+}
+
+function normalizeIsoDate(raw: string): string {
+  // Accept `YYYY-MM-DD` and produce an ISO instant for lexicographic compare.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return `${raw}T00:00:00.000Z`;
+  return raw;
+}
+
+function sha256Hex(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,5 +8,6 @@ export * from './schema.js';
 export * from './db.js';
 export * from './scorer.js';
 export * from './queue.js';
+export * from './backfill.js';
 export * as transcript from './transcript/parser.js';
 export * as llm from './llm/anthropic.js';

--- a/packages/core/test/backfill.test.ts
+++ b/packages/core/test/backfill.test.ts
@@ -1,0 +1,209 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parseSessionFile, scanClaudeHistory } from '../src/backfill.js';
+import { insertPromptUsage, openDb, upsertSession } from '../src/db.js';
+
+/** Build a fake `~/.claude/projects/<project>/<session>.jsonl` hierarchy. */
+function setupFixtureRoot(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'tp-backfill-'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function writeSessionFile(
+  root: string,
+  projectDir: string,
+  sessionId: string,
+  entries: Array<Record<string, unknown>>
+): string {
+  const dir = join(root, projectDir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${sessionId}.jsonl`);
+  const body = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(path, body, 'utf8');
+  return path;
+}
+
+function userEntry(
+  sessionId: string,
+  cwd: string,
+  timestamp: string,
+  content: unknown
+): Record<string, unknown> {
+  return {
+    type: 'user',
+    message: { role: 'user', content },
+    sessionId,
+    cwd,
+    timestamp,
+    gitBranch: 'main',
+    version: '2.1.109',
+    uuid: `u-${Math.random().toString(36).slice(2)}`,
+  };
+}
+
+describe('scanClaudeHistory', () => {
+  it('returns rootExists=false when the directory is absent', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    cleanup(); // remove it so it doesn't exist
+    const stats = scanClaudeHistory(null, { root });
+    expect(stats.rootExists).toBe(false);
+    expect(stats.filesScanned).toBe(0);
+  });
+
+  it('counts user prompts in a single session file', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    try {
+      writeSessionFile(root, '-proj-a', 'session-1', [
+        userEntry('session-1', '/proj/a', '2026-04-01T10:00:00.000Z', 'git pull'),
+        userEntry('session-1', '/proj/a', '2026-04-01T10:05:00.000Z', 'run tests'),
+        // An assistant entry must be ignored.
+        {
+          type: 'assistant',
+          message: { role: 'assistant', content: 'ok' },
+          sessionId: 'session-1',
+          cwd: '/proj/a',
+          timestamp: '2026-04-01T10:00:10.000Z',
+        },
+      ]);
+      const stats = scanClaudeHistory(null, { root });
+      expect(stats.rootExists).toBe(true);
+      expect(stats.filesScanned).toBe(1);
+      expect(stats.filesWithPrompts).toBe(1);
+      expect(stats.totalUserEntries).toBe(2);
+      expect(stats.extractablePrompts).toBe(2);
+      expect(stats.newPrompts).toBe(2);
+      expect(stats.alreadyInDb).toBe(0);
+      expect(stats.distinctSessions).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('dedupes against existing prompt_hash in the DB', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    const dbTmp = mkdtempSync(join(tmpdir(), 'tp-backfill-db-'));
+    try {
+      writeSessionFile(root, '-proj-b', 'session-2', [
+        userEntry('session-2', '/proj/b', '2026-04-02T09:00:00.000Z', 'already imported'),
+        userEntry('session-2', '/proj/b', '2026-04-02T09:05:00.000Z', 'brand new prompt'),
+      ]);
+      const db = openDb(dbTmp);
+      upsertSession(db, { id: 'earlier-session', cwd: '/proj/b' });
+      insertPromptUsage(db, { session_id: 'earlier-session', prompt_text: 'already imported' });
+
+      const stats = scanClaudeHistory(db, { root });
+      expect(stats.extractablePrompts).toBe(2);
+      expect(stats.alreadyInDb).toBe(1);
+      expect(stats.newPrompts).toBe(1);
+      db.close();
+    } finally {
+      cleanup();
+      rmSync(dbTmp, { recursive: true, force: true });
+    }
+  });
+
+  it('honours --since and skips older prompts', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    try {
+      writeSessionFile(root, '-proj-c', 'session-3', [
+        userEntry('session-3', '/proj/c', '2026-03-15T00:00:00.000Z', 'old prompt'),
+        userEntry('session-3', '/proj/c', '2026-04-05T00:00:00.000Z', 'new enough prompt'),
+      ]);
+      const stats = scanClaudeHistory(null, { root, since: '2026-04-01' });
+      expect(stats.extractablePrompts).toBe(1);
+      expect(stats.skippedBySince).toBe(1);
+      expect(stats.totalUserEntries).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('respects --limit on the number of files', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    try {
+      for (let i = 0; i < 5; i++) {
+        writeSessionFile(root, `-proj-${i}`, `session-${i}`, [
+          userEntry(`session-${i}`, `/p/${i}`, `2026-04-0${i + 1}T00:00:00.000Z`, `prompt ${i}`),
+        ]);
+      }
+      const stats = scanClaudeHistory(null, { root, limit: 2 });
+      expect(stats.filesScanned).toBe(2);
+      expect(stats.extractablePrompts).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('filters by --project substring', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    try {
+      writeSessionFile(root, '-repo-alpha', 'session-a', [
+        userEntry('session-a', '/repo/alpha', '2026-04-02T00:00:00.000Z', 'alpha'),
+      ]);
+      writeSessionFile(root, '-repo-beta', 'session-b', [
+        userEntry('session-b', '/repo/beta', '2026-04-02T00:00:00.000Z', 'beta'),
+      ]);
+      const stats = scanClaudeHistory(null, { root, projectFilter: 'alpha' });
+      expect(stats.filesScanned).toBe(1);
+      expect(stats.extractablePrompts).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('extracts text from content-block arrays, not just strings', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    try {
+      writeSessionFile(root, '-proj-d', 'session-4', [
+        userEntry('session-4', '/proj/d', '2026-04-10T00:00:00.000Z', [
+          { type: 'text', text: 'multi' },
+          { type: 'text', text: 'part' },
+        ]),
+      ]);
+      const { prompts } = parseSessionFile(join(root, '-proj-d', 'session-4.jsonl'));
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0]?.promptText).toBe('multi\npart');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('skips malformed JSONL lines without failing the whole file', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    try {
+      const dir = join(root, '-proj-e');
+      mkdirSync(dir, { recursive: true });
+      const content = [
+        JSON.stringify(userEntry('s5', '/proj/e', '2026-04-11T00:00:00.000Z', 'good')),
+        '{ broken json',
+        JSON.stringify(userEntry('s5', '/proj/e', '2026-04-12T00:00:00.000Z', 'also good')),
+      ].join('\n');
+      writeFileSync(join(dir, 'session-5.jsonl'), content, 'utf8');
+
+      const stats = scanClaudeHistory(null, { root });
+      expect(stats.filesFailed).toBe(0);
+      expect(stats.extractablePrompts).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('tracks the earliest and latest timestamps across files', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    try {
+      writeSessionFile(root, '-p1', 's1', [
+        userEntry('s1', '/p1', '2026-01-01T00:00:00.000Z', 'a'),
+      ]);
+      writeSessionFile(root, '-p2', 's2', [
+        userEntry('s2', '/p2', '2026-06-30T00:00:00.000Z', 'b'),
+      ]);
+      const stats = scanClaudeHistory(null, { root });
+      expect(stats.earliestTimestamp).toBe('2026-01-01T00:00:00.000Z');
+      expect(stats.latestTimestamp).toBe('2026-06-30T00:00:00.000Z');
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary / 요약

3개 PR 중 **두 번째** — Claude 히스토리 백필의 dry-run 스캐너.

Second of three PRs. Ships a scan-only backfill that walks `~/.claude/projects/**/*.jsonl` and reports how many user prompts could be imported. Actual import deferred so users see numbers first.

## What's in

- `packages/core/src/backfill.ts` — `scanClaudeHistory`, `parseSessionFile`, `iterateClaudeJsonl`
- `packages/cli/src/commands/backfill.ts` — `think-prompt backfill` with `--dry-run | --limit | --since | --project | --root`
- `packages/core/test/backfill.test.ts` — 9 new tests

## Why split from the import step

At spot-check the author's machine has ~10만 prompts across 928 session files. Shipping scan-only first lets the user:

1. See the distinct-sessions / extractable / already-in-DB / new breakdown
2. Narrow with `--project` or `--since` if desired
3. Decide whether to import all of it

## Usage

```bash
think-prompt backfill                        # scan everything, default limits
think-prompt backfill --limit 50             # preview first 50 files
think-prompt backfill --since 2026-01-01     # only prompts from 2026 onward
think-prompt backfill --project claude-mgmt  # only dirs containing substring
think-prompt backfill --execute              # prints "not yet implemented"
```

Sample output (limit=20 on the author's machine):

```
Claude Code history scan  (125 ms)

  root                        /Users/.../.claude/projects
  files scanned               20
  files with user prompts     20
  distinct sessions           20

  total user entries          1,450
  extractable prompts         129

  already in DB (dedup)       46
  would be imported           83

  earliest timestamp          2026-03-24T01:53:47.540Z
  latest timestamp            2026-04-22T08:37:57.387Z

dry-run only — nothing was written.
```

## Design notes

- **Dedup via `prompt_hash`** (SHA-256). One `SELECT prompt_hash` from the DB at start, then O(1) Set lookup per candidate.
- **Malformed lines skip silently**; only files with zero parseable entries bump `filesFailed`.
- **Empty / command-like entries skipped**: entries must have non-empty `message.content` text. This is why 1,450 raw user entries collapse to 129 extractable prompts in the spot-check (the rest are hook-injected system content or empty).
- **Rule scoring not run** in dry-run — it would be prohibitive without batching. That belongs to `--execute`.

## Test plan / 테스트 계획

- [x] `pnpm typecheck` — 7/7 packages clean
- [x] `pnpm lint` — biome clean
- [x] `pnpm test` — 184/184 passing (+9 backfill)
- [x] Manual spot-check with `--limit 20` on author's machine

## Out of scope — next PR

- `--execute`: wire candidates through `insertPromptUsage` + `runRules`
- Batched transactions, progress bar
- Dashboard "backfilled" badge on imported prompt detail pages
- Session-id collision policy when hook-collected sessions overlap with historical ones

Refs: D-019 (Phase 2), D-004 (local-first)