### PR TITLE
feat(core,cli): Claude 히스토리 백필 --execute 구현 / Implement --execute for Claude history backfill

### DIFF
--- a/packages/cli/src/commands/backfill.ts
+++ b/packages/cli/src/commands/backfill.ts
@@ -1,13 +1,24 @@
 /**
- * `think-prompt backfill` — scan `~/.claude/projects/**\/*.jsonl` and report
- * how many historical user prompts could be imported.
+ * `think-prompt backfill` — scan / import historical user prompts from
+ * `~/.claude/projects/**\/*.jsonl`.
  *
- * This first shipment is DRY-RUN ONLY. `--execute` is deliberately refused
- * with a clear message so the user sees numbers before committing to a
- * potentially tens-of-thousands-of-rows import. A follow-up PR will wire
- * the scanner output into insertPromptUsage + the rules engine.
+ * Modes:
+ *   --dry-run (default) : count only, nothing written
+ *   --execute           : transactional insert with rule scoring
+ *
+ * Common options:
+ *   --limit N           : process at most N .jsonl files
+ *   --since YYYY-MM-DD  : ignore prompts older than this date
+ *   --project <substr>  : filter to project directories containing this
+ *   --root <path>       : override the Claude projects directory
  */
-import { openDb, scanClaudeHistory } from '@think-prompt/core';
+import {
+  type ImportProgress,
+  importClaudeHistory,
+  openDb,
+  scanClaudeHistory,
+} from '@think-prompt/core';
+import { runRules } from '@think-prompt/rules';
 import pc from 'picocolors';
 
 export interface BackfillCmdOptions {
@@ -17,24 +28,49 @@ export interface BackfillCmdOptions {
   since?: string;
   project?: string;
   root?: string;
+  batchSize?: string;
+}
+
+interface ResolvedOptions {
+  execute: boolean;
+  limit: number;
+  batchSize: number;
+  since?: string;
+  project?: string;
+  root?: string;
 }
 
 export async function backfillCmd(opts: BackfillCmdOptions): Promise<void> {
-  if (opts.execute && !opts.dryRun) {
-    console.log(
-      pc.yellow('⚠') + ' --execute is not wired up yet — this release ships scan-only so you can'
-    );
-    console.log('  preview the counts before a mass import. Run without --execute (or with');
-    console.log('  --dry-run) to see what would be imported; real import lands in a follow-up.');
-    return;
-  }
-
   const limit = opts.limit ? Number.parseInt(opts.limit, 10) : 0;
   if (opts.limit && (Number.isNaN(limit) || limit < 0)) {
     console.log(pc.red('✗') + ` invalid --limit value: ${opts.limit}`);
     process.exit(2);
   }
+  const batchSize = opts.batchSize ? Number.parseInt(opts.batchSize, 10) : 500;
+  if (opts.batchSize && (Number.isNaN(batchSize) || batchSize < 1)) {
+    console.log(pc.red('✗') + ` invalid --batch-size value: ${opts.batchSize}`);
+    process.exit(2);
+  }
 
+  const resolved: ResolvedOptions = {
+    execute: opts.execute === true,
+    limit,
+    batchSize,
+    ...(opts.since ? { since: opts.since } : {}),
+    ...(opts.project ? { project: opts.project } : {}),
+    ...(opts.root ? { root: opts.root } : {}),
+  };
+
+  if (resolved.execute) {
+    await runExecute(resolved);
+    return;
+  }
+  await runDryRun(resolved);
+}
+
+// ---------------------- dry-run ------------------------------------------
+
+async function runDryRun(opts: ResolvedOptions): Promise<void> {
   let db: ReturnType<typeof openDb> | null = null;
   try {
     db = openDb();
@@ -49,7 +85,7 @@ export async function backfillCmd(opts: BackfillCmdOptions): Promise<void> {
   console.log(pc.dim(`scanning ${opts.root ?? '~/.claude/projects'} ...`));
   const stats = scanClaudeHistory(db, {
     ...(opts.root ? { root: opts.root } : {}),
-    ...(limit > 0 ? { limit } : {}),
+    ...(opts.limit > 0 ? { limit: opts.limit } : {}),
     ...(opts.since ? { since: opts.since } : {}),
     ...(opts.project ? { projectFilter: opts.project } : {}),
   });
@@ -98,10 +134,68 @@ export async function backfillCmd(opts: BackfillCmdOptions): Promise<void> {
   if (stats.newPrompts > 0) {
     console.log(
       pc.dim(
-        `next step: a future release will add --execute to import these ${stats.newPrompts.toLocaleString()} prompts.`
+        `to import these ${stats.newPrompts.toLocaleString()} prompts: think-prompt backfill --execute`
       )
     );
   }
+}
+
+// ---------------------- execute ------------------------------------------
+
+async function runExecute(opts: ResolvedOptions): Promise<void> {
+  let db: ReturnType<typeof openDb>;
+  try {
+    db = openDb();
+  } catch (err) {
+    console.log(pc.red('✗') + ` could not open local DB (${(err as Error).message})`);
+    process.exit(1);
+    return;
+  }
+
+  console.log(pc.dim(`importing from ${opts.root ?? '~/.claude/projects'} ...`));
+  const isTty = process.stdout.isTTY;
+  const progressLine = (p: ImportProgress): string => {
+    const pct = p.totalCandidates > 0 ? Math.floor((p.processed / p.totalCandidates) * 100) : 0;
+    return `  ${pct.toString().padStart(3)}%  ${p.processed.toLocaleString()}/${p.totalCandidates.toLocaleString()}  imported ${p.imported.toLocaleString()}  failed ${p.failed.toLocaleString()}`;
+  };
+
+  const result = importClaudeHistory(db, {
+    runRules,
+    batchSize: opts.batchSize,
+    ...(opts.root ? { root: opts.root } : {}),
+    ...(opts.limit > 0 ? { limit: opts.limit } : {}),
+    ...(opts.since ? { since: opts.since } : {}),
+    ...(opts.project ? { projectFilter: opts.project } : {}),
+    onProgress: (p) => {
+      const line = progressLine(p);
+      if (isTty) {
+        // Overwrite previous progress line in place.
+        process.stdout.write(`\r${line}\x1b[K`);
+      } else {
+        console.log(line);
+      }
+    },
+  });
+
+  if (isTty) process.stdout.write('\n');
+  db.close();
+
+  console.log('');
+  console.log(pc.bold(`imported  ${pc.dim(`(${(result.durationMs / 1000).toFixed(1)} s)`)}`));
+  console.log('');
+  printRow('files scanned', result.filesScanned.toLocaleString());
+  if (result.filesFailed > 0) {
+    printRow('files failed', pc.yellow(result.filesFailed.toLocaleString()));
+  }
+  printRow('distinct sessions', result.distinctSessions.toLocaleString());
+  printRow('candidates found', result.totalCandidates.toLocaleString());
+  printRow('skipped (duplicates)', pc.dim(result.skippedDup.toLocaleString()));
+  printRow('imported', result.imported > 0 ? pc.green(result.imported.toLocaleString()) : '0');
+  if (result.failed > 0) {
+    printRow('per-row failures', pc.yellow(result.failed.toLocaleString()));
+  }
+  console.log('');
+  console.log(pc.dim('open the dashboard to see the new rows: think-prompt open'));
 }
 
 function printRow(label: string, value: string): void {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -89,13 +89,14 @@ program.command('open').description('open local dashboard in browser').action(op
 
 program
   .command('backfill')
-  .description('scan ~/.claude/projects for historical prompts (dry-run only for now)')
+  .description('scan or import historical prompts from ~/.claude/projects')
   .option('--dry-run', 'preview counts without importing (default)', true)
-  .option('--execute', 'NOT YET IMPLEMENTED — will import in a follow-up release')
-  .option('--limit <n>', 'scan at most N .jsonl files')
+  .option('--execute', 'actually import — transactional, idempotent via prompt_hash dedup')
+  .option('--limit <n>', 'process at most N .jsonl files')
   .option('--since <date>', 'only consider prompts after this date (YYYY-MM-DD)')
   .option('--project <substr>', 'filter to project dirs containing this substring')
   .option('--root <path>', 'override the Claude projects directory')
+  .option('--batch-size <n>', 'transaction batch size when importing (default 500)')
   .action(backfillCmd);
 
 const autostart = program

--- a/packages/core/src/backfill.ts
+++ b/packages/core/src/backfill.ts
@@ -1,11 +1,11 @@
-import { createHash } from 'node:crypto';
 /**
  * Claude Code history backfill — scans `~/.claude/projects/**\/*.jsonl` and
  * reports how many user prompts are there, how many are already present in
  * the Think-Prompt DB, and how many would be new imports.
  *
- * This module is SCAN-ONLY (dry-run). Actual inserts will ship in a
- * follow-up that wires the scanner to insertPromptUsage.
+ * Also exposes `importClaudeHistory` to actually write those prompts into
+ * the local DB (used by `think-prompt backfill --execute`). Import runs
+ * the same rule engine as live capture, so tiers/scores come out consistent.
  *
  * Layout observed on macOS:
  *   ~/.claude/projects/
@@ -25,10 +25,13 @@ import { createHash } from 'node:crypto';
  *     ...
  *   }
  */
+import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Database as Db } from 'better-sqlite3';
+import { insertPromptUsage, insertRuleHit, upsertQualityScore, upsertSession } from './db.js';
+import { composeFinalScore, computeRuleScore } from './scorer.js';
 
 export interface BackfillScanOptions {
   /** Override the Claude projects root. Default: `~/.claude/projects`. */
@@ -321,4 +324,192 @@ function normalizeIsoDate(raw: string): string {
 
 function sha256Hex(s: string): string {
   return createHash('sha256').update(s).digest('hex');
+}
+
+// ----------------------- import (--execute) ------------------------------
+
+/** Signature of `runRules` from @think-prompt/rules. Kept loose here to avoid
+ *  a hard dependency edge from core → rules (core is the lower layer). */
+export type RunRulesFn = (ctx: {
+  promptText: string;
+  session: { cwd: string };
+  meta: { charLen: number; wordCount: number; piiHits?: Record<string, number> };
+}) => Array<{
+  ruleId: string;
+  ruleName: string;
+  severity: number;
+  message: string;
+  evidence?: string | null;
+}>;
+
+export interface ImportProgress {
+  totalCandidates: number;
+  processed: number;
+  imported: number;
+  skippedDup: number;
+  failed: number;
+  currentSession: string;
+}
+
+export interface ImportOptions extends BackfillScanOptions {
+  /** Inject the rules runner so core stays decoupled from the rules package. */
+  runRules: RunRulesFn;
+  /** Transaction batch size. Default 500. */
+  batchSize?: number;
+  /** Optional progress callback (every completed batch). */
+  onProgress?: (p: ImportProgress) => void;
+}
+
+export interface ImportResult {
+  filesScanned: number;
+  filesFailed: number;
+  totalCandidates: number;
+  imported: number;
+  skippedDup: number;
+  failed: number;
+  distinctSessions: number;
+  durationMs: number;
+}
+
+/**
+ * Write every new historical prompt into the local DB, running the same
+ * rule scorer as live capture so tiers/scores are consistent with
+ * hook-collected data.
+ *
+ * Idempotent: re-running is safe — `prompt_hash` dedup catches anything
+ * that was imported on a previous run. Crashes mid-run lose at most
+ * `batchSize-1` rows (transaction rollback).
+ */
+export function importClaudeHistory(db: Db, opts: ImportOptions): ImportResult {
+  const t0 = Date.now();
+  const root = opts.root ?? join(homedir(), '.claude', 'projects');
+  const batchSize = opts.batchSize ?? 500;
+
+  const result: ImportResult = {
+    filesScanned: 0,
+    filesFailed: 0,
+    totalCandidates: 0,
+    imported: 0,
+    skippedDup: 0,
+    failed: 0,
+    distinctSessions: 0,
+    durationMs: 0,
+  };
+
+  if (!existsSync(root)) {
+    result.durationMs = Date.now() - t0;
+    return result;
+  }
+
+  const files = collectJsonlFiles(root, opts.projectFilter);
+  const cap = opts.limit && opts.limit > 0 ? Math.min(files.length, opts.limit) : files.length;
+
+  // Pre-load hash set once. Subsequent dedup within this run is memory-only.
+  const hashSet = loadExistingHashes(db);
+  const sessionSet = new Set<string>();
+  const sessionCwdMap = new Map<string, string>();
+
+  // Gather all candidates first so we can chunk + transaction nicely.
+  // Memory impact: each candidate is ~1 KB average × 100k = ~100 MB.
+  // If that becomes a concern we can stream file-by-file.
+  const candidates: BackfillCandidate[] = [];
+  for (let i = 0; i < cap; i++) {
+    const path = files[i];
+    if (!path) continue;
+    result.filesScanned++;
+    const { failed, prompts } = scanFile(path, opts.since);
+    if (failed) {
+      result.filesFailed++;
+      continue;
+    }
+    for (const c of prompts) {
+      if (hashSet.has(c.promptHash)) {
+        result.skippedDup++;
+        continue;
+      }
+      hashSet.add(c.promptHash); // dedup within this run too
+      sessionCwdMap.set(c.sessionId, c.cwd);
+      candidates.push(c);
+    }
+  }
+  result.totalCandidates = candidates.length;
+
+  // Chronological order per session so turn_index increments correctly.
+  candidates.sort((a, b) => {
+    if (a.sessionId !== b.sessionId) return a.sessionId < b.sessionId ? -1 : 1;
+    return a.timestamp < b.timestamp ? -1 : 1;
+  });
+
+  // Upfront: upsert sessions (one row per distinct sessionId) in a single tx.
+  const upsertSessions = db.transaction(() => {
+    for (const [sid, cwd] of sessionCwdMap) {
+      upsertSession(db, { id: sid, cwd, source: 'claude-code-backfill' });
+      sessionSet.add(sid);
+    }
+  });
+  upsertSessions();
+  result.distinctSessions = sessionSet.size;
+
+  // Process candidates in batches, each batch its own transaction.
+  const insertBatch = db.transaction((items: BackfillCandidate[]) => {
+    for (const c of items) {
+      try {
+        const usage = insertPromptUsage(db, {
+          session_id: c.sessionId,
+          prompt_text: c.promptText,
+          created_at: c.timestamp,
+        });
+        const hits = opts.runRules({
+          promptText: c.promptText,
+          session: { cwd: c.cwd },
+          meta: { charLen: usage.char_len, wordCount: usage.word_count },
+        });
+        for (const h of hits) {
+          insertRuleHit(db, {
+            usage_id: usage.id,
+            rule_id: h.ruleId,
+            severity: h.severity,
+            message: h.message,
+            evidence: h.evidence ?? undefined,
+          });
+        }
+        const ruleScore = computeRuleScore(hits);
+        const { final_score, tier } = composeFinalScore({
+          rule_score: ruleScore,
+          usage_score: null,
+          judge_score: null,
+        });
+        upsertQualityScore(db, {
+          usage_id: usage.id,
+          rule_score: ruleScore,
+          final_score,
+          tier,
+          rules_version: 1,
+        });
+        result.imported++;
+      } catch {
+        // Individual prompt failures (FK constraint, schema drift, malformed
+        // text) drop in 1 attempt instead of rolling back the whole batch.
+        result.failed++;
+      }
+    }
+  });
+
+  for (let i = 0; i < candidates.length; i += batchSize) {
+    const chunk = candidates.slice(i, i + batchSize);
+    insertBatch(chunk);
+    if (opts.onProgress) {
+      opts.onProgress({
+        totalCandidates: candidates.length,
+        processed: Math.min(i + batchSize, candidates.length),
+        imported: result.imported,
+        skippedDup: result.skippedDup,
+        failed: result.failed,
+        currentSession: chunk[chunk.length - 1]?.sessionId ?? '',
+      });
+    }
+  }
+
+  result.durationMs = Date.now() - t0;
+  return result;
 }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -124,11 +124,17 @@ export interface InsertPromptUsageInput {
   turn_index?: number;
   coach_context?: string | null;
   browser_session_id?: string | null;
+  /**
+   * ISO timestamp to persist as `created_at`. Defaults to "now".
+   * Used by the Claude history backfill to preserve original capture times
+   * instead of stamping every imported prompt with today's date.
+   */
+  created_at?: string;
 }
 
 export function insertPromptUsage(db: Db, input: InsertPromptUsageInput): PromptUsageRow {
   const id = ulid();
-  const createdAt = new Date().toISOString();
+  const createdAt = input.created_at ?? new Date().toISOString();
   const hash = sha256Hex(input.prompt_text);
   const { masked, hits } = maskPii(input.prompt_text);
   const wordCount = input.prompt_text.trim().split(/\s+/).filter(Boolean).length;

--- a/packages/core/test/backfill.test.ts
+++ b/packages/core/test/backfill.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { parseSessionFile, scanClaudeHistory } from '../src/backfill.js';
+import {
+  type RunRulesFn,
+  importClaudeHistory,
+  parseSessionFile,
+  scanClaudeHistory,
+} from '../src/backfill.js';
 import { insertPromptUsage, openDb, upsertSession } from '../src/db.js';
 
 /** Build a fake `~/.claude/projects/<project>/<session>.jsonl` hierarchy. */
@@ -204,6 +209,160 @@ describe('scanClaudeHistory', () => {
       expect(stats.latestTimestamp).toBe('2026-06-30T00:00:00.000Z');
     } finally {
       cleanup();
+    }
+  });
+});
+
+describe('importClaudeHistory', () => {
+  // A stub rules runner: flags anything with fewer than 10 chars as R001 sev 2.
+  const stubRunRules: RunRulesFn = ({ promptText }) => {
+    if (promptText.length < 10) {
+      return [
+        {
+          ruleId: 'R001',
+          ruleName: 'too_short',
+          severity: 2,
+          message: 'prompt is very short',
+          evidence: null,
+        },
+      ];
+    }
+    return [];
+  };
+
+  it('imports each candidate into prompt_usages with original timestamp', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    const dbTmp = mkdtempSync(join(tmpdir(), 'tp-import-'));
+    try {
+      writeSessionFile(root, '-proj-x', 'session-x', [
+        userEntry('session-x', '/proj/x', '2026-02-01T10:00:00.000Z', 'first'),
+        userEntry('session-x', '/proj/x', '2026-02-01T10:05:00.000Z', 'second prompt here'),
+      ]);
+      const db = openDb(dbTmp);
+      const result = importClaudeHistory(db, { root, runRules: stubRunRules });
+      expect(result.imported).toBe(2);
+      expect(result.skippedDup).toBe(0);
+      expect(result.distinctSessions).toBe(1);
+
+      // Rows use the JSONL timestamp, not "now".
+      const rows = db
+        .prepare(`SELECT prompt_text, created_at FROM prompt_usages ORDER BY created_at ASC`)
+        .all() as Array<{ prompt_text: string; created_at: string }>;
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.created_at).toBe('2026-02-01T10:00:00.000Z');
+      expect(rows[0]?.prompt_text).toBe('first');
+      expect(rows[1]?.created_at).toBe('2026-02-01T10:05:00.000Z');
+      db.close();
+    } finally {
+      cleanup();
+      rmSync(dbTmp, { recursive: true, force: true });
+    }
+  });
+
+  it('is idempotent — second run adds no new rows', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    const dbTmp = mkdtempSync(join(tmpdir(), 'tp-import-'));
+    try {
+      writeSessionFile(root, '-proj-y', 'session-y', [
+        userEntry('session-y', '/proj/y', '2026-03-01T09:00:00.000Z', 'only one'),
+      ]);
+      const db = openDb(dbTmp);
+      const first = importClaudeHistory(db, { root, runRules: stubRunRules });
+      expect(first.imported).toBe(1);
+
+      const second = importClaudeHistory(db, { root, runRules: stubRunRules });
+      expect(second.imported).toBe(0);
+      expect(second.skippedDup).toBe(1);
+
+      const cnt = db.prepare(`SELECT COUNT(*) AS c FROM prompt_usages`).get() as { c: number };
+      expect(cnt.c).toBe(1);
+      db.close();
+    } finally {
+      cleanup();
+      rmSync(dbTmp, { recursive: true, force: true });
+    }
+  });
+
+  it('runs rules and writes quality_scores + rule_hits', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    const dbTmp = mkdtempSync(join(tmpdir(), 'tp-import-'));
+    try {
+      writeSessionFile(root, '-proj-z', 'session-z', [
+        userEntry('session-z', '/proj/z', '2026-04-01T00:00:00.000Z', 'hi'),
+      ]);
+      const db = openDb(dbTmp);
+      importClaudeHistory(db, { root, runRules: stubRunRules });
+
+      const scores = db.prepare(`SELECT final_score, tier FROM quality_scores`).all() as Array<{
+        final_score: number;
+        tier: string;
+      }>;
+      expect(scores).toHaveLength(1);
+      // Stub rule fires sev=2 -> rule_score = 100 - 5 = 95 -> tier 'good'.
+      expect(scores[0]?.final_score).toBe(95);
+
+      const hits = db.prepare(`SELECT rule_id FROM rule_hits`).all() as Array<{ rule_id: string }>;
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.rule_id).toBe('R001');
+      db.close();
+    } finally {
+      cleanup();
+      rmSync(dbTmp, { recursive: true, force: true });
+    }
+  });
+
+  it('upserts the session row with source=claude-code-backfill', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    const dbTmp = mkdtempSync(join(tmpdir(), 'tp-import-'));
+    try {
+      writeSessionFile(root, '-proj-w', 'session-w', [
+        userEntry('session-w', '/proj/w', '2026-05-01T00:00:00.000Z', 'hello there'),
+      ]);
+      const db = openDb(dbTmp);
+      importClaudeHistory(db, { root, runRules: stubRunRules });
+
+      const session = db
+        .prepare(`SELECT id, cwd, source FROM sessions WHERE id=?`)
+        .get('session-w') as { id: string; cwd: string; source: string };
+      expect(session.cwd).toBe('/proj/w');
+      expect(session.source).toBe('claude-code-backfill');
+      db.close();
+    } finally {
+      cleanup();
+      rmSync(dbTmp, { recursive: true, force: true });
+    }
+  });
+
+  it('reports progress via the callback', () => {
+    const { root, cleanup } = setupFixtureRoot();
+    const dbTmp = mkdtempSync(join(tmpdir(), 'tp-import-'));
+    try {
+      // 7 prompts split across 2 files.
+      writeSessionFile(root, '-p-a', 'session-a', [
+        userEntry('session-a', '/p/a', '2026-01-01T00:00:00.000Z', 'one'),
+        userEntry('session-a', '/p/a', '2026-01-02T00:00:00.000Z', 'two'),
+        userEntry('session-a', '/p/a', '2026-01-03T00:00:00.000Z', 'three'),
+      ]);
+      writeSessionFile(root, '-p-b', 'session-b', [
+        userEntry('session-b', '/p/b', '2026-01-04T00:00:00.000Z', 'four'),
+        userEntry('session-b', '/p/b', '2026-01-05T00:00:00.000Z', 'five'),
+        userEntry('session-b', '/p/b', '2026-01-06T00:00:00.000Z', 'six'),
+        userEntry('session-b', '/p/b', '2026-01-07T00:00:00.000Z', 'seven'),
+      ]);
+      const db = openDb(dbTmp);
+      const calls: number[] = [];
+      importClaudeHistory(db, {
+        root,
+        runRules: stubRunRules,
+        batchSize: 3,
+        onProgress: (p) => calls.push(p.processed),
+      });
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[calls.length - 1]).toBe(7);
+      db.close();
+    } finally {
+      cleanup();
+      rmSync(dbTmp, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary / 요약

**PR B.2** — PR #20(dry-run 스캐너)에 이어 실제 import 를 구현. `~/.claude/projects/**/*.jsonl` 의 유저 프롬프트를 로컬 DB 로 가져온다. 3가지 PR 시리즈(A: 제한 제거 · B: 스캐너 · B.2: 실행) 중 세 번째.

Second phase of the Claude history backfill: actually import the prompts.

## What's new

**core:**
- `importClaudeHistory(db, opts)` — 스캔 → prompt_hash 중복 스킵 → (sessionId, timestamp) 정렬로 turn_index 일관성 확보 → 세션 upsert 1회 → 500행 배치 트랜잭션으로 prompt_usages + rule_hits + quality_scores 삽입. 개별 프롬프트 실패는 배치 전체 롤백 대신 drop.
- `insertPromptUsage(db, {created_at})` — 원본 capture 시각을 보존하도록 옵션 추가. 안 쓰면 기존과 동일하게 "now".
- `core → rules` 역의존 방지: `runRules` 는 `ImportOptions.runRules` 로 주입.

**cli:**
- `think-prompt backfill --execute` — 실제 import.
- `--batch-size N` 옵션 (기본 500).
- 진행률: TTY 면 in-place 갱신, 아니면 줄 단위 로그.

**tests:**
- 5개 신규 테스트 (`importClaudeHistory`):
  - 원본 timestamp 보존
  - 멱등성 (재실행 시 0건 추가)
  - 룰 스코어 + `quality_scores` 기록
  - 세션 `source='claude-code-backfill'` 태깅
  - progress 콜백 호출

## Decisions applied (no user input required)

| Decision | Default |
|---|---|
| 세션 충돌 | `upsertSession` 기존 로직 (`ON CONFLICT DO UPDATE`) |
| `created_at` | JSONL 원본 timestamp |
| 룰 채점 | import 시 바로 실행 |
| 배치 크기 | 500 (트랜잭션 단위) |
| 멱등성 | `prompt_hash` 기반 (재실행 안전) |

## Test plan / 테스트 계획

- [x] `pnpm typecheck` — 7/7 packages clean
- [x] `pnpm lint` — biome clean
- [x] `pnpm test` — 189/189 passing (+5 importClaudeHistory tests)

## Usage

```bash
# Preview first (skip if you already ran it)
think-prompt backfill

# Actually import
think-prompt backfill --execute

# Narrow scope
think-prompt backfill --execute --since 2026-01-01 --limit 100
```

Refs: D-019 (Phase 2), D-004 (local-first), D-028 (fail-open — per-prompt failures don't block the batch)