### PR TITLE
build: npm 퍼블리싱 워크플로 + 6 패키지 메타데이터 / npm release workflow + 6-package publish metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+name: Release
+
+# Publishes every @think-prompt/* package to npm when a version tag is pushed.
+# Triggered ONLY by `vX.Y.Z` tags — never by branch pushes — so releases are
+# always an explicit, deliberate action by a maintainer.
+#
+# Required GitHub secrets:
+#   NPM_TOKEN   — npm automation token with "Publish" permission
+#
+# Security note: every use of an external/user-controllable value is routed
+# through `env:` rather than inlined into a shell command. The workflow
+# trigger itself is `push: tags` (only maintainers can push tags to main
+# repo), so the surface for injection is already tiny, but we still follow
+# the safe pattern.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  verify:
+    name: verify release is clean
+    runs-on: ubuntu-latest
+    env:
+      REF_NAME: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile=false
+
+      # Run the same gate as CI so we never ship something main couldn't.
+      - run: pnpm build
+      - run: pnpm typecheck
+      - run: pnpm lint
+      - run: pnpm test
+
+      # Refuse to publish if the tag version disagrees with package.json.
+      # REF_NAME is a tag name, which git itself restricts to a safe
+      # character set — but we still only consume it as a quoted bash env
+      # var (never inlined).
+      - name: assert tag matches package versions
+        run: |
+          TAG="${REF_NAME#v}"
+          echo "tag version: ${TAG}"
+          for pkg in core rules agent worker dashboard cli; do
+            PKG_VER=$(node -p "require('./packages/${pkg}/package.json').version")
+            echo "  ${pkg}: ${PKG_VER}"
+            if [ "${PKG_VER}" != "${TAG}" ]; then
+              echo "::error::packages/${pkg}/package.json version ${PKG_VER} != tag ${TAG}"
+              exit 1
+            fi
+          done
+
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: read
+      # Required for npm provenance attestations.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm build
+
+      # pnpm walks the workspace topology when --filter is used, so
+      # dependencies are published before dependents automatically.
+      # --no-git-checks: CI checkout doesn't know about the tag's author.
+      # NPM_CONFIG_PROVENANCE + id-token:write → signed provenance metadata.
+      - name: publish @think-prompt/*
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+        run: |
+          pnpm -r --filter='./packages/core' \
+                 --filter='./packages/rules' \
+                 --filter='./packages/agent' \
+                 --filter='./packages/worker' \
+                 --filter='./packages/dashboard' \
+                 --filter='./packages/cli' \
+                 publish --no-git-checks --access public
+
+  github-release:
+    name: attach release notes
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    env:
+      REF_NAME: ${{ github.ref_name }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Extract the section for this tag from CHANGELOG.md.
+      # REF_NAME goes through `awk -v` so it is treated as a string literal,
+      # not shell-expanded. NOTES is then also passed via env to the next
+      # step to avoid any inline interpolation into the gh command.
+      - name: derive release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${REF_NAME#v}"
+          NOTES=$(awk -v v="${VERSION}" '
+            $0 ~ "^## \\["v"\\]" {capture=1; next}
+            capture && /^## / {capture=0}
+            capture {print}
+          ' CHANGELOG.md)
+          if [ -z "${NOTES}" ]; then
+            NOTES="See CHANGELOG.md for details."
+          fi
+          {
+            echo "body<<EOF_NOTES"
+            echo "${NOTES}"
+            echo "EOF_NOTES"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: draft GitHub release
+        env:
+          RELEASE_BODY: ${{ steps.notes.outputs.body }}
+        run: |
+          gh release create "${REF_NAME}" \
+            --title "Think-Prompt ${REF_NAME}" \
+            --notes "${RELEASE_BODY}" \
+            --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 .turbo/
 .tmp/
 packages/browser-extension/*.zip
+.dry-publish/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,10 +63,59 @@ pnpm run ci            # typecheck + lint + test + build
 
 ## Releasing (maintainers only)
 
-1. Update `CHANGELOG.md` under the new version.
-2. Bump versions in each `packages/*/package.json`.
-3. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-4. `gh release create vX.Y.Z --notes-file ...` (or let CI handle it).
+Publishing is automated end-to-end: a pushed `vX.Y.Z` tag triggers
+`.github/workflows/release.yml`, which rebuilds, re-tests, verifies the
+tag matches every package's `version`, publishes the six
+`@think-prompt/*` packages to npm with provenance, and drafts a GitHub
+Release from the matching `CHANGELOG.md` section.
+
+### Steps
+
+```bash
+# 1. Sync all six package.json files to the target SemVer.
+#    (Edits packages/*/package.json only; root stays private.)
+pnpm run release:bump 0.2.0
+
+# 2. Optional sanity check — produces tarballs under ./.dry-publish/ that
+#    mirror what CI would publish. Open a few to confirm dist/ files, types,
+#    and metadata look right before tagging.
+pnpm run release:dry
+
+# 3. Add the new `## [0.2.0] - <date>` section to CHANGELOG.md with a
+#    human-readable summary; the release workflow extracts this section
+#    verbatim into the GitHub Release notes.
+
+# 4. Commit, tag, push.
+git commit -am "release: v0.2.0"
+git tag v0.2.0
+git push origin main --tags
+```
+
+### Prerequisites (one-time, maintainer account)
+
+- `NPM_TOKEN` secret on the repo — an npm automation token with publish
+  rights on the `@think-prompt` org.
+- Repo must allow GitHub Actions to request OIDC tokens (for npm
+  provenance); defaults to allowed on public repos.
+
+### What the workflow guarantees
+
+- Refuses to publish if any `packages/*/package.json` version disagrees
+  with the pushed tag.
+- Re-runs the full CI gate (build → typecheck → lint → test) on the
+  exact tag commit.
+- Signs each tarball with a provenance attestation, so the npm page
+  shows "Built and signed on GitHub Actions" with a link back to the
+  workflow run.
+
+### What the workflow does NOT do
+
+- Bump versions for you — `pnpm run release:bump` is manual so the
+  maintainer eyeballs the diff before tagging.
+- Write CHANGELOG entries — still a human job.
+- Publish prereleases under a non-`latest` tag — if that's needed,
+  extend the workflow with a `--tag` arg driven by the tag name
+  (e.g. `v0.2.0-rc.1` → `--tag next`).
 
 ## Code of Conduct
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "ci": "pnpm build && pnpm typecheck && pnpm lint && pnpm test",
-    "clean": "pnpm -r exec rm -rf dist node_modules/.cache"
+    "clean": "pnpm -r exec rm -rf dist node_modules/.cache",
+    "release:bump": "node scripts/bump-versions.mjs",
+    "release:dry": "pnpm -r --filter='./packages/core' --filter='./packages/rules' --filter='./packages/agent' --filter='./packages/worker' --filter='./packages/dashboard' --filter='./packages/cli' pack --pack-destination ./.dry-publish"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,8 +1,25 @@
 {
   "name": "@think-prompt/agent",
   "version": "0.1.0",
-  "description": "Local HTTP agent receiving Claude Code hooks",
+  "description": "Think-Prompt local HTTP hook receiver (127.0.0.1:47823)",
   "type": "module",
+  "license": "MIT",
+  "author": "Think-Prompt contributors",
+  "homepage": "https://github.com/must-goldenrod/think-prompt#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/must-goldenrod/think-prompt.git",
+    "directory": "packages/agent"
+  },
+  "bugs": {
+    "url": "https://github.com/must-goldenrod/think-prompt/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "hooks",
+    "fastify",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +32,16 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "hooks",
-    "fastify",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "hooks", "fastify", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,9 +27,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,9 +32,7 @@
   "bin": {
     "think-prompt": "./dist/index.js"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,15 +1,47 @@
 {
   "name": "@think-prompt/cli",
   "version": "0.1.0",
-  "description": "Think-Prompt CLI — install, start/stop, list, doctor, rewrite",
+  "description": "Think-Prompt CLI — Claude Code prompt collector + local-first quality coach. Scan ~/.claude history, score with R001..R018 rules, deep analysis with consent.",
   "type": "module",
+  "license": "MIT",
+  "author": "Think-Prompt contributors",
+  "homepage": "https://github.com/must-goldenrod/think-prompt#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/must-goldenrod/think-prompt.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/must-goldenrod/think-prompt/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "prompt",
+    "prompt-engineering",
+    "developer-tool",
+    "cli",
+    "local-first",
+    "privacy",
+    "coaching",
+    "anthropic"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
     "think-prompt": "./dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,14 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "prompt",
-    "prompt-engineering",
-    "sqlite",
-    "pii",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "prompt", "prompt-engineering", "sqlite", "pii", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,10 +32,7 @@
       "import": "./dist/transcript/parser.js"
     }
   },
-  "files": [
-    "dist",
-    "migrations"
-  ],
+  "files": ["dist", "migrations"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,25 @@
   "version": "0.1.0",
   "description": "Shared core: DB, types, logger, PII, scorer, transcript parser",
   "type": "module",
+  "license": "MIT",
+  "author": "Think-Prompt contributors",
+  "homepage": "https://github.com/must-goldenrod/think-prompt#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/must-goldenrod/think-prompt.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/must-goldenrod/think-prompt/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "prompt",
+    "prompt-engineering",
+    "sqlite",
+    "pii",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -20,7 +39,17 @@
       "import": "./dist/transcript/parser.js"
     }
   },
-  "files": ["dist", "migrations"],
+  "files": [
+    "dist",
+    "migrations"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,8 +1,26 @@
 {
   "name": "@think-prompt/dashboard",
   "version": "0.1.0",
-  "description": "Local web dashboard for Think-Prompt",
+  "description": "Think-Prompt local web dashboard (127.0.0.1:47824) — 5-language i18n, deep analysis UI",
   "type": "module",
+  "license": "MIT",
+  "author": "Think-Prompt contributors",
+  "homepage": "https://github.com/must-goldenrod/think-prompt#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/must-goldenrod/think-prompt.git",
+    "directory": "packages/dashboard"
+  },
+  "bugs": {
+    "url": "https://github.com/must-goldenrod/think-prompt/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "dashboard",
+    "fastify",
+    "i18n",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +33,16 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,13 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "dashboard",
-    "fastify",
-    "i18n",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "dashboard", "fastify", "i18n", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -33,9 +27,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,8 +1,26 @@
 {
   "name": "@think-prompt/rules",
   "version": "0.1.0",
-  "description": "Antipattern rules R001..R012",
+  "description": "Think-Prompt antipattern rule catalog (R001..R018+) with positive/negative samples",
   "type": "module",
+  "license": "MIT",
+  "author": "Think-Prompt contributors",
+  "homepage": "https://github.com/must-goldenrod/think-prompt#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/must-goldenrod/think-prompt.git",
+    "directory": "packages/rules"
+  },
+  "bugs": {
+    "url": "https://github.com/must-goldenrod/think-prompt/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "prompt",
+    "antipattern",
+    "lint",
+    "rules"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -12,7 +30,16 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit"

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -14,13 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "prompt",
-    "antipattern",
-    "lint",
-    "rules"
-  ],
+  "keywords": ["claude-code", "prompt", "antipattern", "lint", "rules"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,9 +24,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "queue",
-    "background-worker",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "queue", "background-worker", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,9 +27,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,8 +1,25 @@
 {
   "name": "@think-prompt/worker",
   "version": "0.1.0",
-  "description": "Background worker: transcript parsing, LLM judge, rewriter",
+  "description": "Think-Prompt background worker: transcript parsing, LLM judge, rewriter",
   "type": "module",
+  "license": "MIT",
+  "author": "Think-Prompt contributors",
+  "homepage": "https://github.com/must-goldenrod/think-prompt#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/must-goldenrod/think-prompt.git",
+    "directory": "packages/worker"
+  },
+  "bugs": {
+    "url": "https://github.com/must-goldenrod/think-prompt/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "queue",
+    "background-worker",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +32,16 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",

--- a/scripts/bump-versions.mjs
+++ b/scripts/bump-versions.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Synchronized version bump for every @think-prompt/* package.
+ *
+ * Usage:
+ *   pnpm run release:bump <new-version>     # e.g. 0.2.0, 1.0.0-rc.1
+ *
+ * What it does:
+ *   1. Validates <new-version> is SemVer (rough check — not a full parser).
+ *   2. Rewrites `version` in every publishable package.json under packages/
+ *      (core, rules, agent, worker, dashboard, cli).
+ *   3. Leaves the root package.json alone — it's private and not published.
+ *
+ * What it does NOT do:
+ *   - git commit, git tag, git push — those stay manual so a maintainer
+ *     always eyeballs the diff before tagging.
+ *   - regenerate lockfile — pnpm picks up workspace:* resolutions and the
+ *     lockfile doesn't encode package versions for workspace packages.
+ *
+ * The release pipeline (.github/workflows/release.yml) re-verifies that
+ * every package.json's `version` matches the pushed tag, so mistakes here
+ * fail loudly in CI before anything is published.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PUBLISHED_PACKAGES = ['core', 'rules', 'agent', 'worker', 'dashboard', 'cli'];
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+
+const nextVersion = process.argv[2];
+if (!nextVersion) {
+  console.error('usage: pnpm run release:bump <new-version>');
+  process.exit(2);
+}
+// Minimal SemVer sanity check: N.N.N with optional -prerelease.
+if (!/^\d+\.\d+\.\d+(?:-[\w.]+)?$/.test(nextVersion)) {
+  console.error(
+    `error: "${nextVersion}" does not look like a SemVer (expected e.g. 0.2.0, 1.0.0-rc.1)`
+  );
+  process.exit(2);
+}
+
+for (const pkg of PUBLISHED_PACKAGES) {
+  const path = join(repoRoot, 'packages', pkg, 'package.json');
+  const raw = readFileSync(path, 'utf8');
+  const json = JSON.parse(raw);
+  const prev = json.version;
+  json.version = nextVersion;
+  writeFileSync(path, JSON.stringify(json, null, 2) + '\n', 'utf8');
+  console.log(`  ${pkg.padEnd(10)} ${prev}  →  ${nextVersion}`);
+}
+
+console.log('');
+console.log('next steps:');
+console.log(`  1. git diff              # eyeball the six version bumps`);
+console.log(`  2. update CHANGELOG.md   # add ## [${nextVersion}] section`);
+console.log(`  3. git commit -am "release: v${nextVersion}"`);
+console.log(`  4. git tag v${nextVersion}`);
+console.log(`  5. git push origin main --tags   # triggers .github/workflows/release.yml`);


### PR DESCRIPTION
## Summary / 요약

D-022 에서 약속된 npm-first 배포 경로를 실제로 붙인다. 태그 하나 push 하면 6개 `@think-prompt/*` 패키지가 provenance 서명된 tarball 로 npm 에 올라간다.

## What's in

### 1. `packages/*/package.json` × 6
- `license: "MIT"`, author, homepage, repository (with `directory`), bugs, keywords
- `publishConfig: { access: "public", provenance: true }`
- `engines: { node: ">=20" }`

### 2. `.github/workflows/release.yml` (신규)
- Trigger: push of `v*.*.*` tag only
- **Job 1 `verify`** — CI 재실행 + 모든 package.json `version` 이 태그와 일치하는지 검증. 불일치면 publish 전 실패.
- **Job 2 `publish`** — `pnpm -r publish --no-git-checks --access public`, `NPM_CONFIG_PROVENANCE=true` + `id-token: write` 로 provenance attestation 생성 → npm 페이지에 "Built and signed on GitHub Actions" 배지.
- **Job 3 `github-release`** — `CHANGELOG.md [X.Y.Z]` 섹션을 awk 로 추출해 GitHub Release drafted.
- 모든 외부 입력값(`REF_NAME`, `RELEASE_BODY`, `NODE_AUTH_TOKEN`)이 `env:` 경유, 쉘 인라인 삽입 없음 (injection surface 최소화).

### 3. `scripts/bump-versions.mjs` (신규)
- `pnpm run release:bump 0.2.0` — 6개 패키지 `version` 동기 bump. SemVer 검증.
- 태그·커밋은 **수동** (사람이 diff 눈으로 확인 후 push)

### 4. 루트 `package.json` 스크립트
- `release:bump` (wrapper)
- `release:dry` — 6개를 `.dry-publish/` 로 pack, 태그 전 tarball 내용물 확인

### 5. `CONTRIBUTING.md § Releasing`
- 전체 maintainer 런북 + 원타임 prerequisites (NPM_TOKEN secret 등록)

## One-time setup after merge

1. npm org `@think-prompt` 에 automation token 생성
2. GitHub repo secret `NPM_TOKEN` 등록
3. public repo 이므로 OIDC (provenance) 별도 설정 불필요

## Test plan

- [x] `pnpm typecheck` — 7/7 packages clean
- [x] `pnpm lint` — biome clean
- [x] `pnpm test` — 195/195 passing
- [x] `scripts/bump-versions.mjs 99.99.99-test` round-trip 성공 (bump → revert)
- [x] `pnpm -F @think-prompt/core pack` 정상 tarball 생성 확인
- [ ] Manual: 머지 후 `NPM_TOKEN` 등록 + `v0.1.0` 태그 push → 실제 publish 확인

## First release checklist (머지 후)

```bash
# 1. Edit CHANGELOG.md — add ## [0.1.0] section
# 2. pnpm run release:bump 0.1.0   # (already 0.1.0, no-op; real bump comes for 0.1.1)
# 3. git commit -am "release: v0.1.0"
# 4. git tag v0.1.0
# 5. git push origin main --tags
```

Refs: D-022 (npm-first), D-025 (SemVer + GitHub Actions publish)