### PR TITLE
feat: npm 단일 번들 배포 구조 (D-034) / Single-bundle npm publishing structure (D-034)

### DIFF
--- a/docs/00-decision-log.md
+++ b/docs/00-decision-log.md
@@ -248,5 +248,33 @@
 
 ---
 
+## D-034 · npm 배포 구조: 단일 번들 + 스코프 방어 선점
+- **날짜:** 2026-04-23
+- **컨텍스트:** v0.1.0 을 npm 에 공개 배포할 시점. 모노레포는 7개 패키지(`cli / core / rules / agent / worker / dashboard / browser-extension`) 인데 이들 중 **어떤 단위로 npm 에 publish 할지** 결정 필요.
+- **대안:**
+  - ① `@think-prompt/*` 6개 패키지 모두 scoped publish — 표준 모노레포 배포. core/rules 를 라이브러리로 외부에 공개.
+  - ② 단일 `think-prompt` 언스코프드 패키지로 **5개 워크스페이스 코드를 cli dist 에 번들** — CLI 도구 관례 (vercel, pm2, biome 패턴).
+  - ③ 둘 다 publish (cli 는 thin re-export) — 유지 비용 가장 큼.
+- **결정:** **②** 채택. 추가로 **`@think-prompt` organization 만 npm 에서 무료 claim** 해서 브랜드 스쿼팅 방지.
+- **근거:**
+  - **유저 미션과의 정렬.** D-032 두 근본 문제(인지 고착 / 프롬프트 자각 부재) 해결의 표면은 **CLI + 대시보드** 단 둘. core/rules 를 라이브러리로 노출해도 미션에 직접 기여 안 함.
+  - **유지 비용.** ① 은 6 README · changesets · 6× 공개 API 계약 (Tier 1/2 내부 구조가 그대로 공개 표면이 됨) · 버전 sync 이슈. 1인 유지보수 기준 과함.
+  - **유저 멘탈 모델.** "내가 체감하는 건 대시보드뿐" — 유저 직접 피드백(2026-04-22). 5개 데몬/배관은 구현 세부이고, npm 페이지에 6개를 노출하면 혼란만 가중.
+  - **확장 가능성.** ② → ① 은 후행 추가 가능 (스코프만 잡혀있으면). ① → ② 는 이미 publish 된 패키지 deprecate · 이관 비용 발생. **회복 가능한 방향**으로 결정.
+  - **이름 가용성.** `think-prompt` (언스코프드) · `@think-prompt/*` 모두 2026-04-23 기준 미선점 확인 (npm 404).
+- **구현:**
+  - `packages/cli/tsup.config.ts` — `noExternal: [/^@think-prompt\//]` 로 5개 워크스페이스 번들.
+  - `packages/cli/package.json` — `name: "think-prompt"`, workspace deps 제거, transitive 외부 deps (`better-sqlite3`, `fastify`, `pino`, `zod`, `franc-min`, `commander`, `picocolors`) 직접 등록. `publishConfig.access: "public"`, `repository`, `license: "MIT"`, `keywords`, `homepage`, `bugs` 추가.
+  - `packages/cli/{README.md, LICENSE}` — npm 페이지 표시용. 루트 README 의 핵심 섹션 추출.
+  - 다른 5개 패키지(`@think-prompt/agent` 등) 는 `private: true` 로 모노레포 내부용으로만 유지.
+  - 유저 액션: `npm login` → https://www.npmjs.com/org/create 에서 `think-prompt` org 무료 생성 → `npm publish` (단일 패키지).
+- **영향:**
+  - 엔드유저 설치: `npm i -g think-prompt` 한 줄.
+  - 내부 리팩터(패키지 이름·구조 변경) 자유 — 공개 API 표면이 CLI 서브커맨드 출력 포맷뿐.
+  - core/rules 를 라이브러리로 쓰고 싶은 외부 요청이 누적되면 D-035 로 ① 모드 추가 가능.
+- **관계:** D-004(로컬 중심) · D-028(fail-open) · D-032(미션 정렬) 와 정합. D-001(로컬 우선) 의 npm 배포 표면을 구체화.
+
+---
+
 ## 취소된 결정
 *(없음 — 새 결정이 기존 것을 번복할 때 여기에 기록)*

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -14,7 +14,12 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": ["claude-code", "hooks", "fastify", "local-first"],
+  "keywords": [
+    "claude-code",
+    "hooks",
+    "fastify",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -27,7 +32,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true
@@ -49,5 +56,6 @@
     "typescript": "^5.7.2",
     "tsup": "^8.3.5",
     "vitest": "^2.1.8"
-  }
+  },
+  "private": true
 }

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pro-Prompt contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,92 @@
+# think-prompt
+
+> Claude Code에 **프롬프트 개인 코치**를 붙여주는 로컬-전용 오픈소스 도구.
+
+[![npm version](https://img.shields.io/npm/v/think-prompt.svg)](https://www.npmjs.com/package/think-prompt)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![GitHub](https://img.shields.io/badge/GitHub-must--goldenrod%2Fthink--prompt-181717?logo=github)](https://github.com/must-goldenrod/think-prompt)
+
+---
+
+## 한 줄 요약
+
+여러분이 Claude Code에 **어떤 프롬프트를 어떻게 치는지** 로컬에 기록하고,
+**어디가 부족한지 조용히 알려주는** 무료 도구. **내 컴퓨터 밖으로 데이터가 나가지 않습니다.**
+
+---
+
+## 🚀 30초 설치
+
+```bash
+# Node 20+ 필요
+npm i -g think-prompt
+think-prompt install        # 훅 + 데몬 자동 설정
+# Claude Code를 평소대로 쓰고
+think-prompt open           # 대시보드 오픈 (http://127.0.0.1:47824)
+```
+
+처음이라면 → **[📘 완전 입문 가이드](https://github.com/must-goldenrod/think-prompt/blob/main/docs/GUIDE.md)**
+
+---
+
+## ✨ 뭘 해주나요?
+
+1. **자동 수집** — Claude Code 훅으로 모든 프롬프트·세션·서브에이전트 호출을 로컬 SQLite에 저장
+2. **품질 진단** — 12개 안티패턴 룰(R001~R012)로 0–100점 자동 채점
+3. **자동 리라이트(선택)** — Anthropic API 키 있으면 낮은 점수 프롬프트를 더 나은 버전으로 다시 씁니다
+4. **로컬 대시보드** — `http://127.0.0.1:47824` — tier 분포·TOP 5 낮은 점수·세션 타임라인
+5. **인라인 코칭(선택)** — 모호한 프롬프트에 Claude가 답하기 전에 "확인 질문부터" 안내
+
+---
+
+## 🔒 프라이버시 약속
+
+- **원문 프롬프트는 여러분 PC 밖으로 나가지 않습니다.**
+- 서버 동기화 모드 없음 (v0.1 기준)
+- LLM 기능을 켰을 때만 마스킹된 사본이 Anthropic에 갑니다 — 이미 Claude Code가 하는 일과 같은 범위
+- PII(이메일·전화·API 키·JWT 등)는 저장 전 자동 마스킹
+- `think-prompt wipe --yes` 한 줄로 **모든 데이터 + 훅 완전 제거**
+
+---
+
+## 🧰 주요 명령어
+
+```bash
+think-prompt install         # 훅 + 데몬 설치
+think-prompt uninstall       # 제거 (데이터 유지, --purge 로 완전 삭제)
+think-prompt start/stop/restart
+think-prompt status          # 데몬 3개 상태
+think-prompt doctor          # 건강 진단
+
+think-prompt list [--tier bad] [--rule R003] [--limit 20]
+think-prompt show <id>       # 프롬프트 상세 + 룰 히트 + 점수
+think-prompt rewrite <id>    # LLM 리라이트 제안
+
+think-prompt open            # 대시보드 브라우저 오픈
+think-prompt wipe --yes      # 완전 삭제
+```
+
+전체 18개 명령어와 옵션은 `think-prompt --help` 참조.
+
+---
+
+## 📦 시스템 요구사항
+
+- **Node.js 20+** (22 권장)
+- **macOS · Linux** — Windows는 Phase 2
+- **Claude Code CLI** 설치 필요 (훅 등록 대상)
+
+---
+
+## 🔗 관련 링크
+
+- **GitHub:** https://github.com/must-goldenrod/think-prompt
+- **이슈/제안:** https://github.com/must-goldenrod/think-prompt/issues
+- **설계 문서:** [docs/](https://github.com/must-goldenrod/think-prompt/tree/main/docs)
+- **결정 로그(D-번호):** [docs/00-decision-log.md](https://github.com/must-goldenrod/think-prompt/blob/main/docs/00-decision-log.md)
+
+---
+
+## 📜 라이선스
+
+MIT — 자유롭게 쓰세요.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@think-prompt/cli",
+  "name": "think-prompt",
   "version": "0.1.0",
-  "description": "Think-Prompt CLI — Claude Code prompt collector + local-first quality coach. Scan ~/.claude history, score with R001..R018 rules, deep analysis with consent.",
+  "description": "Local-first prompt coach for Claude Code — collects your prompts via hooks, scores them with rules, and shows patterns in a private dashboard. No data leaves your machine.",
   "type": "module",
   "license": "MIT",
-  "author": "Think-Prompt contributors",
+  "author": "must-goldenrod",
   "homepage": "https://github.com/must-goldenrod/think-prompt#readme",
   "repository": {
     "type": "git",
@@ -24,7 +24,9 @@
     "local-first",
     "privacy",
     "coaching",
-    "anthropic"
+    "anthropic",
+    "anti-pattern",
+    "hooks"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -32,30 +34,35 @@
   "bin": {
     "think-prompt": "./dist/index.js"
   },
-  "files": ["dist"],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "pnpm -w run build"
   },
   "dependencies": {
+    "better-sqlite3": "^11.7.0",
+    "commander": "^12.1.0",
+    "fastify": "^5.2.0",
+    "franc-min": "^6.2.0",
+    "picocolors": "^1.1.1",
+    "pino": "^9.5.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
     "@think-prompt/agent": "workspace:*",
     "@think-prompt/core": "workspace:*",
     "@think-prompt/dashboard": "workspace:*",
     "@think-prompt/rules": "workspace:*",
     "@think-prompt/worker": "workspace:*",
-    "commander": "^12.1.0",
-    "picocolors": "^1.1.1"
-  },
-  "devDependencies": {
-    "typescript": "^5.7.2",
     "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   }
 }

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -5,7 +5,7 @@
 import { spawn } from 'node:child_process';
 import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getPaths } from '@think-prompt/core';
 
@@ -36,12 +36,15 @@ export function isRunning(pid: number | null): boolean {
 }
 
 export function resolveEntry(role: Role): string {
+  // Production (bundled): cli/dist/index.js + cli/dist/daemons/<role>.js
+  const bundled = join(__dirname, 'daemons', `${role}.js`);
+  if (existsSync(bundled)) return bundled;
+
+  // Dev fallback: monorepo workspace path
   const require = createRequire(import.meta.url);
-  // Resolve the package's main entry. Works in a published npm install.
   try {
     return require.resolve(`@think-prompt/${role}`);
   } catch {
-    // Fallback: monorepo relative path (for dev).
     return require.resolve(`../../${role}/dist/index.js`);
   }
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,11 +1,17 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    'daemons/agent': '../agent/src/index.ts',
+    'daemons/worker': '../worker/src/index.ts',
+    'daemons/dashboard': '../dashboard/src/index.ts',
+  },
   format: ['esm'],
   dts: false,
   sourcemap: true,
   clean: true,
   target: 'node20',
   banner: { js: '#!/usr/bin/env node' },
+  noExternal: [/^@think-prompt\//],
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,14 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": ["claude-code", "prompt", "prompt-engineering", "sqlite", "pii", "local-first"],
+  "keywords": [
+    "claude-code",
+    "prompt",
+    "prompt-engineering",
+    "sqlite",
+    "pii",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,7 +39,10 @@
       "import": "./dist/transcript/parser.js"
     }
   },
-  "files": ["dist", "migrations"],
+  "files": [
+    "dist",
+    "migrations"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true
@@ -55,5 +65,6 @@
     "typescript": "^5.7.2",
     "tsup": "^8.3.5",
     "vitest": "^2.1.8"
-  }
+  },
+  "private": true
 }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,13 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": ["claude-code", "dashboard", "fastify", "i18n", "local-first"],
+  "keywords": [
+    "claude-code",
+    "dashboard",
+    "fastify",
+    "i18n",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -27,7 +33,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true
@@ -48,5 +56,6 @@
     "typescript": "^5.7.2",
     "tsup": "^8.3.5",
     "vitest": "^2.1.8"
-  }
+  },
+  "private": true
 }

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -14,7 +14,13 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": ["claude-code", "prompt", "antipattern", "lint", "rules"],
+  "keywords": [
+    "claude-code",
+    "prompt",
+    "antipattern",
+    "lint",
+    "rules"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -24,7 +30,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true
@@ -41,5 +49,6 @@
     "typescript": "^5.7.2",
     "tsup": "^8.3.5",
     "vitest": "^2.1.8"
-  }
+  },
+  "private": true
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -14,7 +14,12 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": ["claude-code", "queue", "background-worker", "local-first"],
+  "keywords": [
+    "claude-code",
+    "queue",
+    "background-worker",
+    "local-first"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -27,7 +32,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true
@@ -48,5 +55,6 @@
     "typescript": "^5.7.2",
     "tsup": "^8.3.5",
     "vitest": "^2.1.8"
-  }
+  },
+  "private": true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,28 @@ importers:
 
   packages/cli:
     dependencies:
+      better-sqlite3:
+        specifier: ^11.7.0
+        version: 11.10.0
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+      fastify:
+        specifier: ^5.2.0
+        version: 5.8.5
+      franc-min:
+        specifier: ^6.2.0
+        version: 6.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
       '@think-prompt/agent':
         specifier: workspace:*
         version: link:../agent
@@ -94,13 +116,6 @@ importers:
       '@think-prompt/worker':
         specifier: workspace:*
         version: link:../worker
-      commander:
-        specifier: ^12.1.0
-        version: 12.1.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)


### PR DESCRIPTION
## Summary / 요약

v0.1.0 npm 공개 배포를 위해 **CLI 한 패키지만 `think-prompt` 이름으로 퍼블리시**하고, 5개 내부 워크스페이스(`@think-prompt/{core,rules,agent,worker,dashboard}`)는 `private: true` 로 모노레포 전용으로 유지. D-034 참조.

- `packages/cli/package.json` — name `@think-prompt/cli` → `think-prompt` (unscoped), workspace deps → devDependencies, transitive 외부 deps 직접 등록.
- `packages/cli/tsup.config.ts` — 3 daemon entry 추가, `noExternal: [/^@think-prompt\//]`.
- `packages/cli/src/daemon.ts` — `resolveEntry()` 가 번들 경로 우선, dev fallback.
- `packages/{agent,core,worker,dashboard,rules}/package.json` — `private: true`.
- `packages/cli/{README.md, LICENSE}` 신규.
- `docs/00-decision-log.md` — D-034 append.

Publish one unscoped `think-prompt` package that bundles 5 internal workspaces into its dist. Keep workspaces `private: true`. Daemon resolver prefers bundled path, falls back to workspace in dev.

## Why / 근거

- D-032 미션 정렬: 유저 체감 표면은 CLI + 대시보드.
- 1인 유지보수 기준 6 README · changesets · 6× 공개 API 계약은 과함.
- ② → ① 은 후행 추가 가능, ① → ② 는 deprecate 비용 — 회복 가능한 방향.
- `think-prompt` (unscoped), `@think-prompt/*` 모두 2026-04-23 기준 미선점 확인.

Aligned with D-032 mission; lower maintenance cost for solo maintainer; reversible direction.

## Test plan / 테스트

- [x] `pnpm -r build` 성공
- [x] cli dist 에 `daemons/{agent,worker,dashboard}.js` 생성 확인
- [ ] `npm pack --dry-run` 배포 아티팩트 검증
- [ ] 격리 환경(`THINK_PROMPT_HOME=/tmp/...`)에서 install/status/doctor/open 통과
- [ ] 후속 액션: `npm login` + `@think-prompt` org claim + `npm publish`

Refs: D-004 (local-first), D-028 (fail-open), D-032 (mission alignment), D-034 (this decision)