### PR TITLE
feat(site): 브랜딩 랜딩 페이지 + GitHub Pages 배포 + main lint 복구 / Landing page + Pages deploy + lint recovery

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,51 @@
+name: Deploy Site
+
+# Publishes `site/` to GitHub Pages on every push to main that touches
+# those files. The site is a single static HTML file plus a tiny CSS —
+# no build step, we just upload `site/` as the Pages artifact.
+#
+# One-time maintainer setup:
+#   Repo Settings -> Pages -> Source = "GitHub Actions"
+#   (Optional) Custom domain -> think-prompt.dev, DNS CNAME to
+#   <user>.github.io, GitHub auto-issues a Let's Encrypt cert.
+#
+# Security: no run: steps use shell interpolation of user-controllable
+# inputs. Triggers exclude PRs so forks cannot touch Pages.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: upload site/ artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "hooks",
-    "fastify",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "hooks", "fastify", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,9 +27,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,14 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "prompt",
-    "prompt-engineering",
-    "sqlite",
-    "pii",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "prompt", "prompt-engineering", "sqlite", "pii", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,10 +32,7 @@
       "import": "./dist/transcript/parser.js"
     }
   },
-  "files": [
-    "dist",
-    "migrations"
-  ],
+  "files": ["dist", "migrations"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,13 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "dashboard",
-    "fastify",
-    "i18n",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "dashboard", "fastify", "i18n", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -33,9 +27,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -14,13 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "prompt",
-    "antipattern",
-    "lint",
-    "rules"
-  ],
+  "keywords": ["claude-code", "prompt", "antipattern", "lint", "rules"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,9 +24,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/must-goldenrod/think-prompt/issues"
   },
-  "keywords": [
-    "claude-code",
-    "queue",
-    "background-worker",
-    "local-first"
-  ],
+  "keywords": ["claude-code", "queue", "background-worker", "local-first"],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,9 +27,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,56 @@
+# `site/` — Think-Prompt landing page
+
+Single-page marketing site for https://think-prompt.dev (or whatever domain
+we end up pointing at GitHub Pages).
+
+## Stack
+
+**Deliberately static.** Tailwind CDN + a tiny custom stylesheet + one
+`copyInstall()` JS function. No bundler, no build step. This mirrors the
+same philosophy as the local dashboard (D-012 in the decision log: "server-
+rendered HTML + Tailwind CDN, no bundler").
+
+- `index.html` — the whole page
+- `style.css` — focus rings, font smoothing, scrollbar polish
+- `README.md` — this file
+
+## Local preview
+
+Any HTTP server works. From the repo root:
+
+```bash
+cd site
+python3 -m http.server 8000
+# or
+npx --yes http-server -p 8000 .
+```
+
+Then open http://localhost:8000.
+
+## Deployment
+
+GitHub Pages deploys automatically from `main` via
+`.github/workflows/deploy-site.yml`. One-time setup by a maintainer:
+
+1. Repo **Settings → Pages** → Source = `GitHub Actions`.
+2. (Optional) Custom domain → add `think-prompt.dev`. Set CNAME in
+   your DNS to `<user>.github.io`. GitHub auto-issues a Let's Encrypt cert.
+3. Push to `main` — the workflow publishes `site/` as the root of the site.
+
+## Content changes
+
+Edit `index.html` directly. The file is kept as a single flat document on
+purpose — easier to audit, easier to review in PRs, and fast to load for
+visitors. If it grows past ~400 lines, consider splitting into an `index.html`
++ `components/` pattern, but only when the split pays for itself.
+
+Keep the privacy promises (D-004 / D-028 / D-030 section) word-for-word
+consistent with the decision log. If they ever diverge, the log wins and
+the homepage gets a PR.
+
+## Assets (TODO)
+
+- [ ] Replace the placeholder demo block with a 30-second GIF before v0.1.0
+      launch (see `docs/10-launch-strategy.md` §0).
+- [ ] Add favicon + Open Graph image (1200×630 PNG).
+- [ ] Custom domain DNS once it's purchased.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Think-Prompt — a local-first Claude Code prompt coach</title>
+  <meta name="description" content="See which of your Claude Code prompts actually work. 18 antipattern rules, 5-language dashboard, opt-in LLM deep analysis. Local-first — prompts never leave your machine." />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Think-Prompt — local-first Claude Code prompt coach" />
+  <meta property="og:description" content="Score every Claude Code prompt against 18 antipattern rules. Runs entirely on your machine." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://think-prompt.dev" />
+  <meta name="twitter:card" content="summary_large_image" />
+
+  <!-- Tailwind CDN (same philosophy as the dashboard, D-012: no bundler) -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            ink: '#0b0d12',
+            accent: '#6366f1',
+            good: '#22c55e',
+            ok: '#eab308',
+            weak: '#f97316',
+            bad: '#ef4444',
+          },
+          fontFamily: {
+            sans: ['-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Inter', 'sans-serif'],
+            mono: ['ui-monospace', 'SF Mono', 'Menlo', 'Monaco', 'monospace'],
+          },
+        },
+      },
+    };
+  </script>
+
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body class="bg-white text-ink antialiased">
+
+  <!-- NAV -->
+  <header class="border-b border-gray-100">
+    <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2 font-bold text-lg">
+        <span class="inline-block w-2 h-2 rounded-full bg-accent"></span>
+        Think-Prompt
+      </a>
+      <nav class="text-sm flex gap-6 text-gray-600">
+        <a href="#features" class="hover:text-ink">Features</a>
+        <a href="#privacy" class="hover:text-ink">Privacy</a>
+        <a href="https://github.com/must-goldenrod/think-prompt" class="hover:text-ink">GitHub</a>
+        <a href="https://github.com/must-goldenrod/think-prompt/tree/main/docs" class="hover:text-ink">Docs</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- HERO -->
+  <section class="max-w-5xl mx-auto px-6 pt-20 pb-16">
+    <div class="text-xs font-mono text-accent mb-4 tracking-widest uppercase">Local-first · MIT · v0.1.0</div>
+    <h1 class="text-5xl md:text-6xl font-bold tracking-tight leading-[1.05] mb-6">
+      See which of your<br />
+      Claude Code prompts<br />
+      <span class="text-accent">actually work.</span>
+    </h1>
+    <p class="text-xl text-gray-600 max-w-2xl mb-10 leading-relaxed">
+      Think-Prompt scores every prompt you send in Claude Code against 18 antipattern rules, shows a tiered dashboard, and — with your consent — runs a deep LLM analysis to diagnose what's wrong and rewrite it.
+      <strong class="text-ink">Runs entirely on your machine.</strong>
+    </p>
+
+    <!-- Install command block with copy button -->
+    <div class="max-w-xl">
+      <div class="flex items-center gap-2 bg-ink text-gray-100 rounded-lg px-5 py-4 font-mono text-sm shadow-lg">
+        <span class="text-gray-500 select-none">$</span>
+        <code id="install-cmd" class="flex-1 overflow-x-auto whitespace-nowrap">npm install -g @think-prompt/cli</code>
+        <button
+          onclick="copyInstall()"
+          class="ml-3 px-3 py-1 text-xs bg-white/10 hover:bg-white/20 rounded transition-colors"
+          aria-label="Copy install command">
+          <span id="copy-label">Copy</span>
+        </button>
+      </div>
+      <div class="flex gap-4 mt-4 text-sm text-gray-500 font-mono">
+        <code>think-prompt install</code>
+        <span>→</span>
+        <code>think-prompt open</code>
+      </div>
+    </div>
+
+    <!-- Placeholder for demo — real GIF drops in before v0.1.0 launch -->
+    <div class="mt-16 rounded-xl border border-gray-200 bg-gradient-to-br from-gray-50 to-white p-10 shadow-sm">
+      <div class="text-center text-gray-400 text-sm font-mono mb-4">[ 30-second demo placeholder ]</div>
+      <div class="grid grid-cols-5 gap-2 max-w-md mx-auto">
+        <div class="h-14 bg-good rounded" title="good"></div>
+        <div class="h-14 bg-ok rounded" title="ok"></div>
+        <div class="h-14 bg-weak rounded" title="weak"></div>
+        <div class="h-14 bg-bad rounded" title="bad"></div>
+        <div class="h-14 bg-gray-300 rounded" title="n/a"></div>
+      </div>
+      <div class="text-center text-xs text-gray-500 mt-3 font-mono">good · ok · weak · bad · n/a</div>
+    </div>
+  </section>
+
+  <!-- FEATURES -->
+  <section id="features" class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-3xl font-bold mb-2">What's in it</h2>
+    <p class="text-gray-600 mb-12">Four things, no fluff.</p>
+
+    <div class="grid md:grid-cols-2 gap-4">
+      <!-- Feature 1 -->
+      <div class="border border-gray-200 rounded-xl p-6 hover:border-accent hover:shadow-md transition-all">
+        <div class="flex items-center gap-3 mb-3">
+          <span class="w-8 h-8 rounded-lg bg-accent/10 text-accent flex items-center justify-center font-mono text-sm">1</span>
+          <h3 class="font-bold text-lg">Auto capture</h3>
+        </div>
+        <p class="text-gray-600 leading-relaxed">
+          Installs as a Claude Code hook and quietly records every prompt you send, every subagent you dispatch, every tool call outcome — into a SQLite file at <code class="text-xs bg-gray-100 rounded px-1.5 py-0.5">~/.think-prompt/prompts.db</code>.
+        </p>
+      </div>
+
+      <!-- Feature 2 -->
+      <div class="border border-gray-200 rounded-xl p-6 hover:border-accent hover:shadow-md transition-all">
+        <div class="flex items-center gap-3 mb-3">
+          <span class="w-8 h-8 rounded-lg bg-accent/10 text-accent flex items-center justify-center font-mono text-sm">2</span>
+          <h3 class="font-bold text-lg">18 antipattern rules</h3>
+        </div>
+        <p class="text-gray-600 leading-relaxed">
+          R001 <em>too short</em> · R002 <em>no output format</em> · R003 <em>no context</em> · R004 <em>multi-task</em> · R010 <em>no constraint</em> … deterministic scoring with explanations you can actually debug.
+        </p>
+      </div>
+
+      <!-- Feature 3 -->
+      <div class="border border-gray-200 rounded-xl p-6 hover:border-accent hover:shadow-md transition-all">
+        <div class="flex items-center gap-3 mb-3">
+          <span class="w-8 h-8 rounded-lg bg-accent/10 text-accent flex items-center justify-center font-mono text-sm">3</span>
+          <h3 class="font-bold text-lg">Deep analysis (opt-in)</h3>
+        </div>
+        <p class="text-gray-600 leading-relaxed">
+          With your explicit consent, send the PII-masked prompt to Claude Haiku. Get back categorized problems, step-by-step reasoning, and a rewrite. Stored locally; used nowhere else.
+        </p>
+      </div>
+
+      <!-- Feature 4 -->
+      <div class="border border-gray-200 rounded-xl p-6 hover:border-accent hover:shadow-md transition-all">
+        <div class="flex items-center gap-3 mb-3">
+          <span class="w-8 h-8 rounded-lg bg-accent/10 text-accent flex items-center justify-center font-mono text-sm">4</span>
+          <h3 class="font-bold text-lg">Backfill history</h3>
+        </div>
+        <p class="text-gray-600 leading-relaxed">
+          One command imports every prompt from <code class="text-xs bg-gray-100 rounded px-1.5 py-0.5">~/.claude/projects</code> — often 10,000+ prompts going back months. Dedup via hash; rule-scored on the way in.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- PRIVACY -->
+  <section id="privacy" class="bg-gradient-to-br from-gray-50 to-white py-20">
+    <div class="max-w-5xl mx-auto px-6">
+      <h2 class="text-3xl font-bold mb-2">Your prompts, your machine</h2>
+      <p class="text-gray-600 mb-10">Three promises we've written into the decision log.</p>
+
+      <div class="grid md:grid-cols-3 gap-4">
+        <div class="bg-white border border-gray-200 rounded-xl p-6">
+          <div class="text-xs font-mono text-gray-500 mb-2">D-004</div>
+          <h3 class="font-bold mb-2">Local-first</h3>
+          <p class="text-sm text-gray-600 leading-relaxed">
+            Prompt text is stored on your disk and nowhere else. There is no server — not because we didn't build it, but because <em>we won't</em>.
+          </p>
+        </div>
+
+        <div class="bg-white border border-gray-200 rounded-xl p-6">
+          <div class="text-xs font-mono text-gray-500 mb-2">D-028</div>
+          <h3 class="font-bold mb-2">Fail-open</h3>
+          <p class="text-sm text-gray-600 leading-relaxed">
+            Think-Prompt never blocks Claude Code. If our daemon crashes, your editor keeps working. Data loss is preferred over your interruption.
+          </p>
+        </div>
+
+        <div class="bg-white border border-gray-200 rounded-xl p-6">
+          <div class="text-xs font-mono text-gray-500 mb-2">D-030</div>
+          <h3 class="font-bold mb-2">No telemetry</h3>
+          <p class="text-sm text-gray-600 leading-relaxed">
+            No crash reports, no usage pings, no anonymous analytics. The only outbound network call in the whole project is the opt-in LLM analysis — and it goes directly to Anthropic with your key.
+          </p>
+        </div>
+      </div>
+
+      <div class="mt-10 text-sm text-gray-500">
+        Read every decision in
+        <a href="https://github.com/must-goldenrod/think-prompt/blob/main/docs/00-decision-log.md" class="text-accent hover:underline">docs/00-decision-log.md</a>.
+      </div>
+    </div>
+  </section>
+
+  <!-- QUICKSTART -->
+  <section class="max-w-5xl mx-auto px-6 py-20">
+    <h2 class="text-3xl font-bold mb-2">Sixty seconds</h2>
+    <p class="text-gray-600 mb-10">From nothing to a dashboard with real data.</p>
+
+    <ol class="space-y-6">
+      <li class="flex gap-5">
+        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-ink text-white flex items-center justify-center font-mono text-sm">1</span>
+        <div class="flex-1">
+          <p class="font-semibold mb-1">Install</p>
+          <code class="block bg-ink text-gray-100 rounded px-4 py-2 font-mono text-sm">npm install -g @think-prompt/cli</code>
+        </div>
+      </li>
+      <li class="flex gap-5">
+        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-ink text-white flex items-center justify-center font-mono text-sm">2</span>
+        <div class="flex-1">
+          <p class="font-semibold mb-1">Wire up the hooks + start daemons</p>
+          <code class="block bg-ink text-gray-100 rounded px-4 py-2 font-mono text-sm">think-prompt install</code>
+        </div>
+      </li>
+      <li class="flex gap-5">
+        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-ink text-white flex items-center justify-center font-mono text-sm">3</span>
+        <div class="flex-1">
+          <p class="font-semibold mb-1">(Optional) Import your Claude Code history</p>
+          <code class="block bg-ink text-gray-100 rounded px-4 py-2 font-mono text-sm">think-prompt backfill --execute</code>
+          <p class="text-xs text-gray-500 mt-1">Reads <code>~/.claude/projects</code>. Dry-run first without <code>--execute</code> to see the count.</p>
+        </div>
+      </li>
+      <li class="flex gap-5">
+        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-ink text-white flex items-center justify-center font-mono text-sm">4</span>
+        <div class="flex-1">
+          <p class="font-semibold mb-1">Open the dashboard</p>
+          <code class="block bg-ink text-gray-100 rounded px-4 py-2 font-mono text-sm">think-prompt open</code>
+        </div>
+      </li>
+    </ol>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="border-t border-gray-100 mt-10">
+    <div class="max-w-5xl mx-auto px-6 py-10 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+      <div class="text-sm text-gray-500">
+        <div class="font-semibold text-ink mb-1">Think-Prompt</div>
+        MIT licensed. Built for developers who want to know.
+      </div>
+      <div class="flex gap-6 text-sm">
+        <a href="https://github.com/must-goldenrod/think-prompt" class="text-gray-500 hover:text-ink">GitHub</a>
+        <a href="https://www.npmjs.com/package/@think-prompt/cli" class="text-gray-500 hover:text-ink">npm</a>
+        <a href="https://github.com/must-goldenrod/think-prompt/discussions" class="text-gray-500 hover:text-ink">Discussions</a>
+        <a href="https://github.com/must-goldenrod/think-prompt/blob/main/CHANGELOG.md" class="text-gray-500 hover:text-ink">Changelog</a>
+        <a href="https://github.com/must-goldenrod/think-prompt/blob/main/SECURITY.md" class="text-gray-500 hover:text-ink">Security</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function copyInstall() {
+      const cmd = document.getElementById('install-cmd').textContent;
+      navigator.clipboard.writeText(cmd).then(() => {
+        const label = document.getElementById('copy-label');
+        const prev = label.textContent;
+        label.textContent = 'Copied!';
+        setTimeout(() => { label.textContent = prev; }, 1500);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,28 @@
+/* Minimal site-specific CSS. Tailwind covers almost everything; this file
+ * holds a few things that are awkward to do purely in utility classes:
+ * scrollbar styling on the install command, smoother focus rings, and
+ * a subtle gradient text option for the accent heading that only works
+ * with plain CSS. */
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* Improve focus ring for keyboard users without over-styling mouse users. */
+:focus-visible {
+  outline: 2px solid rgb(99 102 241);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+/* The horizontal scroll inside the install command block — keep it from
+ * showing an ugly OS-native scrollbar. */
+#install-cmd::-webkit-scrollbar {
+  height: 0;
+}


### PR DESCRIPTION
## Summary / 요약

**PR F** — v0.1.0 런칭용 브랜딩 페이지. 이전 `feat/landing-page` 브랜치는 다른 PR(D-034 단일 번들 구조)에 재사용되어 별도 브랜치로 분리.

## What's in

### 1. `site/` (신규)
- **`index.html`** — Hero · Features(4) · Privacy(D-004/D-028/D-030) · Quickstart(4단계) · Footer
- **`style.css`** — 포커스 링 · 폰트 feature · 스크롤바 폴리시
- **`README.md`** — 로컬 프리뷰 방법 · 배포 구조 · TODO

Tailwind CDN + 순수 JS `copyInstall()` 한 함수. **빌드 스텝 0** (D-012 철학 재사용).

### 2. `.github/workflows/deploy-site.yml` (신규)
- `site/**` 변경 시에만 트리거 (PR 제외 — fork 보안)
- `actions/configure-pages` + `upload-pages-artifact` + `deploy-pages` 조합
- 외부 입력값 쉘 interpolation 없음

### 3. `packages/*/package.json` 포맷 복구 (부수적)

PR #25(D-034 단일 번들) 머지 과정에서 biome 룰과 어긋난 포맷이 main 에 들어갔다. `biome check --write` 로 5개 package.json 원래 포맷 복구.
- 변경은 **공백·줄바꿈뿐**, 필드 값 변경 없음
- main 의 lint CI 가 실패 중이던 것을 이 PR 에서 함께 해제

## One-time maintainer action (머지 후)

1. Repo Settings → Pages → Source = "GitHub Actions"
2. 첫 트리거: 머지 시 자동
3. (옵션) Custom domain `think-prompt.dev` 구매 후 CNAME 설정

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (포맷 복구 포함)
- [x] `pnpm test` — 195/195 passing
- [x] 로컬 프리뷰 확인 (site/ → http.server)
- [ ] 머지 후 GitHub Pages 실제 배포 한 번 동작 확인

## TODO before v0.1.0 launch

- [ ] 30초 데모 GIF 교체
- [ ] Favicon + OG 이미지
- [ ] 도메인 확정

Refs: D-012, D-034