### PR TITLE
feat(dashboard): 자동 새로고침 강화 — 3s 폴링·focus/pageshow·전 페이지 커버 / Reliable live-refresh

### DIFF
--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -19,7 +19,7 @@ export interface LayoutOptions {
    * on views whose data changes on new-prompt arrival (Overview, Prompts
    * list) — leave off on detail pages to preserve scroll/inputs.
    */
-  liveRefresh?: boolean;
+  liveRefresh?: { latestId: string | null };
 }
 
 export function layout(
@@ -42,7 +42,9 @@ export function layout(
     })
     .join('');
   const langSwitcher = renderLanguageSwitcher(locale, opts);
-  const liveScript = opts.liveRefresh ? LIVE_REFRESH_SCRIPT : '';
+  const liveScript = opts.liveRefresh
+    ? `<script>document.documentElement.setAttribute('data-latest-id', ${JSON.stringify(opts.liveRefresh.latestId ?? '')});</script>${LIVE_REFRESH_SCRIPT}`
+    : '';
 
   return `<!DOCTYPE html>
 <html lang="${locale}">
@@ -135,10 +137,12 @@ function renderLanguageSwitcher(locale: Locale, opts: LayoutOptions): string {
 const LIVE_REFRESH_SCRIPT = `<script>
 (function () {
   const INITIAL = document.documentElement.getAttribute('data-latest-id') || '';
-  const INTERVAL_MS = 6000;
+  const INTERVAL_MS = 3000;
   let stopped = false;
+  let inflight = false;
   async function tick() {
-    if (stopped || document.hidden) return;
+    if (stopped || inflight || document.hidden) return;
+    inflight = true;
     try {
       const r = await fetch('/api/overview/latest-id', { cache: 'no-store' });
       if (!r.ok) return;
@@ -149,11 +153,14 @@ const LIVE_REFRESH_SCRIPT = `<script>
       }
     } catch (_) {
       // Network blip — try again next tick.
+    } finally {
+      inflight = false;
     }
   }
-  document.addEventListener('visibilitychange', () => {
-    if (!document.hidden && !stopped) tick();
-  });
+  const wake = () => { if (!document.hidden && !stopped) tick(); };
+  document.addEventListener('visibilitychange', wake);
+  window.addEventListener('focus', wake);
+  window.addEventListener('pageshow', wake);
   setInterval(tick, INTERVAL_MS);
 })();
 </script>`;

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -78,11 +78,6 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     return row?.id ?? null;
   }
 
-  /** Inject the current latestId so the polling script can diff it. */
-  function latestIdBootScript(id: string | null): string {
-    return `<script>document.documentElement.setAttribute('data-latest-id', ${JSON.stringify(id ?? '')});</script>`;
-  }
-
   fastify.get('/health', async () => ({ ok: true }));
 
   /** Live-refresh polling target — cheap, returns JSON, no HTML. */
@@ -241,7 +236,6 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     const chartHtml = renderDailyChart(days);
 
     const body = `
-      ${latestIdBootScript(latestPromptId())}
       <h1 class="text-2xl font-bold mb-6">${escapeHtml(t(locale, 'overview.title'))}</h1>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
         <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-5">
@@ -309,7 +303,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       layout(t(locale, 'overview.title'), body, locale, {
         reqPath: '/',
         reqQuery: reqQueryPassthrough(req),
-        liveRefresh: true,
+        liveRefresh: { latestId: latestPromptId() },
       })
     );
   });
@@ -370,7 +364,6 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     ];
 
     const body = `
-      ${latestIdBootScript(latestPromptId())}
       <h1 class="text-2xl font-bold mb-4">${escapeHtml(t(locale, 'prompts.title'))}</h1>
       <form class="mb-4 flex gap-3 text-sm flex-wrap">
         <input type="hidden" name="lang" value="${escapeHtml(locale)}" />
@@ -427,7 +420,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       layout(t(locale, 'prompts.title'), body, locale, {
         reqPath: '/prompts',
         reqQuery: reqQueryPassthrough(req),
-        liveRefresh: true,
+        liveRefresh: { latestId: latestPromptId() },
       })
     );
   });
@@ -570,6 +563,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       layout(t(locale, 'detail.title'), body, locale, {
         reqPath: `/prompts/${u.id}`,
         reqQuery: reqQueryPassthrough(req),
+        liveRefresh: { latestId: latestPromptId() },
       })
     );
   });
@@ -731,6 +725,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       layout(t(locale, 'rules.title'), body, locale, {
         reqPath: '/rules',
         reqQuery: reqQueryPassthrough(req),
+        liveRefresh: { latestId: latestPromptId() },
       })
     );
   });
@@ -795,6 +790,7 @@ think-prompt coach on</pre>
       layout(t(locale, 'doctor.title'), body, locale, {
         reqPath: '/doctor',
         reqQuery: reqQueryPassthrough(req),
+        liveRefresh: { latestId: latestPromptId() },
       })
     );
   });

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -482,3 +482,64 @@ describe('renderDailyChart', () => {
     expect(svg).toContain('font-family="ui-monospace');
   });
 });
+
+// Live-refresh reliability: poll faster, cover more routes, and listen on
+// focus/pageshow so throttled background tabs still update promptly.
+describe('dashboard live-refresh', () => {
+  it('polls every 3 seconds (snappier than the old 6s)', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/INTERVAL_MS\s*=\s*3000/);
+    await app.close();
+  });
+
+  it('listens on focus and pageshow in addition to visibilitychange', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.body).toContain("addEventListener('focus'");
+    expect(res.body).toContain("addEventListener('pageshow'");
+    expect(res.body).toContain("addEventListener('visibilitychange'");
+    await app.close();
+  });
+
+  it('auto-refreshes on prompt detail pages', async () => {
+    const db = openDb();
+    upsertSession(db, { id: 's-d', cwd: '/tmp' });
+    const u = insertPromptUsage(db, { session_id: 's-d', prompt_text: 'hi' });
+    db.close();
+
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: `/prompts/${u.id}?lang=en` });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('data-latest-id');
+    expect(res.body).toContain('/api/overview/latest-id');
+    await app.close();
+  });
+
+  it('auto-refreshes on rules catalog', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/rules?lang=en' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('data-latest-id');
+    expect(res.body).toContain('/api/overview/latest-id');
+    await app.close();
+  });
+
+  it('auto-refreshes on doctor page', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/doctor?lang=en' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('data-latest-id');
+    expect(res.body).toContain('/api/overview/latest-id');
+    await app.close();
+  });
+
+  it('does NOT auto-refresh on settings (has edit forms — reload would lose input)', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/settings?lang=en' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toContain('/api/overview/latest-id');
+    await app.close();
+  });
+});


### PR DESCRIPTION
## 요약 / Summary

대시보드가 **새 프롬프트가 들어와도 자동으로 반영되지 않는** 문제 해결. 원인은 3가지가 겹침:
1. 폴링 주기 **6초** 가 느리게 체감됨
2. `visibilitychange` 만 구독 → 창 포커스 전환 시 깨우지 못함
3. `liveRefresh` 가 Overview + Prompts list **2개 라우트에만** 적용 → Detail·Rules·Doctor 페이지 진입 시 자동 갱신 OFF

Dashboard didn't pick up newly captured prompts without a manual refresh.
Three overlapping causes: 6s polling felt sluggish, only `visibilitychange`
was wired (ignoring window-focus), and `liveRefresh` was enabled on just
Overview + Prompts list — Detail, Rules, Doctor got no updates.

## 변경 / Changes

| 영역 | Before | After |
|---|---|---|
| 폴링 주기 | 6000ms | **3000ms** |
| Wake events | visibilitychange | visibilitychange + **focus** + **pageshow** |
| 중복 방지 | — | **inflight 플래그** |
| liveRefresh 커버 | 2 라우트 | **5 라우트** (+ detail, rules, doctor) |
| settings 페이지 | — | **명시적으로 off** (폼 입력 보호) |
| 부트스크립트 주입 | 라우트별 inline | **layout() 중앙화** |

옵션 타입 변경: `liveRefresh: boolean` → `liveRefresh: { latestId: string | null }`.
라우트는 한 줄만 쓰면 layout()이 `data-latest-id` 부트 스크립트 + 폴링 IIFE 모두 주입. 기존 인라인 `latestIdBootScript` 호출 제거, 헬퍼도 같이 정리.

## 부하 영향 / Load impact

1 탭 기준 **20 req/min** (기존 10 req/min). 각 요청은 `ORDER BY created_at DESC LIMIT 1` 단일 쿼리로 SQLite WAL에서 μs 단위 실행. 2~3 탭이 열려도 60~80 req/min 로 워커 부하 대비 noise-floor 이하. 유저가 요청한 "부하가 심하지 않게" 충족.

SSE 전환도 검토했으나 단일 유저 로컬 툴에선 구조 복잡도 증가 대비 체감 차이가 작아 폴링을 유지. 추후 멀티탭이 기본 사용 패턴이 되면 재검토.

One tab polls 20 req/min (up from 10). Each request runs one
`ORDER BY created_at DESC LIMIT 1` query — sub-millisecond on local
SQLite WAL. Even 2-3 tabs stay well under the worker's noise floor.
Looked at SSE but the complexity/latency trade isn't worth it for a
local single-user tool.

## 테스트 계획 / Test plan

- [x] `pnpm -F @think-prompt/dashboard exec vitest run` — **37/37 pass** (31 + 6 신규)
- [x] `pnpm typecheck` — 7/7 packages pass
- [x] 로컬 빌드 + 47824 재기동 후 라이브 검증:
  - `/` HTML 에 INTERVAL_MS=3000, focus, pageshow, data-latest-id 포함
  - `/prompts/:id`, `/rules`, `/doctor` 에 data-latest-id + /api/overview/latest-id 포함
  - `/settings` 에 /api/overview/latest-id **미포함** (의도대로)
- [ ] 리뷰어: Overview 탭을 백그라운드 보낸 뒤 Claude Code 에서 프롬프트 3~4개 입력 → 탭 복귀 시 1프레임 내 자동 reload 되는지 실측

## 신규 테스트 / New tests

1. `polls every 3 seconds (snappier than the old 6s)`
2. `listens on focus and pageshow in addition to visibilitychange`
3. `auto-refreshes on prompt detail pages`
4. `auto-refreshes on rules catalog`
5. `auto-refreshes on doctor page`
6. `does NOT auto-refresh on settings`