### PR TITLE
feat(dashboard): 사이트와 브랜드 토큰 통일 (D-037) / Align dashboard brand tokens with site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,54 @@ stability guarantees of v1.0 do not yet apply.
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+---
+
+## [0.2.0] — 2026-04-23
+
+Dashboard UX + brand alignment release. Adds 30-day default / long-window
+month labels to the chart, replaces manual-refresh with real live updates
+across the whole dashboard, hides the internal rules catalog from the
+main nav, and pulls the dashboard's colors / fonts / card tone into
+alignment with the marketing site. Backfill + live-capture pipelines
+unchanged.
+
 ### Added
 - **R013 `pii_detected`** — new safety rule that escalates severity 1 → 3
   based on how many distinct PII categories the masker caught in the
   prompt (email / phone / RRN / API keys / JWT / IP). Addresses C-036.
 - **R014 `vague_adverb`** — new style rule flagging 좀/대충/그냥/kinda/
   probably/maybe etc. Addresses C-023.
+- **Dashboard period selector** — 7 · 14 · 30 · 90 · 365 · all pills on
+  the Overview chart; default 30 days. `?days=` query param is the
+  single source of truth for window size.
+- **Chart: dense-mode axis labels** — charts with n > 45 bars switch
+  from per-day `MM/DD` to per-month `YY-MM` labels and suppress
+  per-bar totals, so 90/365/all views stay readable. PR #26, D-none.
+- **Live-refresh coverage** — `/prompts/:id`, `/rules`, `/doctor` now
+  auto-reload when a new prompt lands, matching Overview + Prompts
+  list. `/settings` deliberately excluded to preserve form input.
+  PR #28.
 
 ### Changed
-- **R004 `multiple_tasks`** now also fires on `//` or `/` separators when
-  combined with ≥ 2 imperative verbs, catching the "요약 // 번역 // 표로"
-  pattern that slipped through the conjunction-only detection.
+- **Live-refresh interval 6 s → 3 s** with `focus` + `pageshow` event
+  listeners added to `visibilitychange`, so background-throttled tabs
+  tick within one frame of returning to focus instead of up to a
+  minute later. PR #28.
+- **Rules catalog (`/rules`) removed from the main nav** — route still
+  responds for README/issue deep-links, but the meta-view is no
+  longer a user-facing tab. D-036 · PR #29.
+- **Dashboard brand tokens unified with the marketing site** — shared
+  `ink: #0b0d12` and `accent: #6366f1` (indigo) tokens, Inter + SF
+  Mono font cascade, accent-colored `:focus-visible` ring, accent dot
+  before the wordmark. All `blue-6xx` utility classes swapped to the
+  `accent` token; cards moved from `rounded-lg shadow` to
+  `rounded-xl border shadow-sm` for a flatter, site-matching tone.
+  D-037 · PR #30.
+- **R004 `multiple_tasks`** now also fires on `//` or `/` separators
+  when combined with ≥ 2 imperative verbs, catching the "요약 // 번역
+  // 표로" pattern that slipped through the conjunction-only detection.
   Addresses C-004.
 - **R012 `code_dump_no_instruction`** threshold lowered 80% → 65% after
   dogfooding surfaced the "7 lines of code + short question" pattern
@@ -30,13 +67,14 @@ stability guarantees of v1.0 do not yet apply.
   C-049 / C-050.
 
 ### Testing
-- Rule suite: 11 → 22 tests. Total: 53 → 64 tests, all passing.
+- Dashboard suite: 28 → **45 tests** (+17 covering chart dense mode,
+  live-refresh coverage + wake events, rules-hidden regression, brand
+  tokens and blue-class absence).
+- Full suite: 53 → **212 tests**, all passing across 23 files.
 
-### To verify
-- **M0 observation spike** — confirm Claude Code hook payloads and
-  `transcript.jsonl` field names against the assumptions encoded in
-  `packages/core/src/schema.ts` and `packages/core/src/transcript/parser.ts`.
-  See `docs/99-observation-log.md` for the 10 open questions.
+### Decisions logged
+- **D-036** · Rules catalog hidden from user-facing nav.
+- **D-037** · Dashboard brand tokens unified with `site/index.html`.
 
 ---
 

--- a/docs/00-decision-log.md
+++ b/docs/00-decision-log.md
@@ -293,5 +293,27 @@
 
 ---
 
+## D-037 · 대시보드 브랜드 토큰 사이트와 통일 (ink · accent · font · 카드)
+
+- **Date:** 2026-04-23
+- **Problem:** 랜딩(`site/index.html`)과 로컬 대시보드가 같은 프로덕트인데 브랜드 신호가 달랐다. 사이트는 `accent: #6366f1` (indigo) + `ink: #0b0d12` 토큰을 쓰고, Inter cascade + mono 시그너처 라벨·accent 포커스 링·도트 로고로 정체성을 만들어 놓았는데, 대시보드는 Tailwind 기본 `blue-600` 과 일반 `rounded-lg shadow` 카드로 전혀 다른 얼굴이었음. D-032 미션("유저의 두 근본 문제 해결")을 위해서도 마케팅→대시보드 전환 시 같은 제품을 쓰고 있다는 즉각적 신호가 중요.
+- **Decision:** 대시보드 `layout()` 의 `tailwind.config.extend` 에 사이트와 동일한 `ink`·`accent`·`fontFamily` 토큰을 추가하고, 전체 UI 에서 다음을 일괄 스왑.
+  - `blue-600/700` 계열 → `accent`, `accent/90` 호버
+  - 카드 컨테이너 `rounded-lg shadow` → `rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm` (사이트처럼 가벼운 그림자 + 은은한 테두리)
+  - `<style>` 블록에 `:focus-visible` accent 링 + `font-feature-settings: "ss01", "cv11"` + antialiased 정렬
+  - 로고 앞에 `w-2 h-2 rounded-full bg-accent` 도트
+  - deep analysis 강조 카드의 좌측 4px 컬러바를 `border-purple-500` → `border-l-accent`
+- **Rationale:**
+  - 최소 변경으로 최대 체감 일치 — 색과 폰트만 통일해도 "같은 제품" 인상의 80%.
+  - 대시보드 고유성(데이터 밀도, `max-w-6xl`, 작은 h1/h2, 다크모드)은 **의도적으로 보존** — 마케팅과 데이터 UI 는 목적이 달라 타이포 리듬까지 일치시키면 화면이 비효율적.
+  - 기본 그림자 → 가벼운 테두리 전환은 "정돈된 작업대" 톤을 유지하면서 사이트의 flat + subtle 감각과 정합.
+- **Alternatives considered:**
+  - ② 사이트 레이아웃까지 그대로 복제(`max-w-5xl`, 5xl 히어로 H1 등) — 데이터 밀도 손해, 반려.
+  - ③ 다크 모드용 별도 `ink-dark`/`accent-dark` 토큰 분화 — indigo-500 이 다크 배경에서도 충분한 대비를 가지므로 지금은 과잉.
+- **Scope:** `packages/dashboard/src/html.ts`·`server.ts` 색상·폰트·카드 · 테스트 정규식 업데이트 · 신규 회귀 테스트 5건. `packages/browser-extension` 은 스코프 외(별 건).
+- **관계:** D-012(번들러 없음) — Tailwind CDN 그대로 사용 · D-032(미션 정렬) — 동일 브랜드 신호가 유저의 "이 도구가 나를 위한 것" 인식 강화.
+
+---
+
 ## 취소된 결정
 *(없음 — 새 결정이 기존 것을 번복할 때 여기에 기록)*

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/agent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Think-Prompt local HTTP hook receiver (127.0.0.1:47823)",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "think-prompt",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local-first prompt coach for Claude Code — collects your prompts via hooks, scores them with rules, and shows patterns in a private dashboard. No data leaves your machine.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared core: DB, types, logger, PII, scorer, transcript parser",
   "type": "module",
   "license": "MIT",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/dashboard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Think-Prompt local web dashboard (127.0.0.1:47824) — 5-language i18n, deep analysis UI",
   "type": "module",
   "license": "MIT",

--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -37,7 +37,7 @@ export function layout(
   const navHtml = navItems
     .map(([href, key]) => {
       const url = appendLangParam(href, locale);
-      return `<a href="${url}" class="hover:text-blue-600">${escapeHtml(t(locale, key))}</a>`;
+      return `<a href="${url}" class="hover:text-accent transition-colors">${escapeHtml(t(locale, key))}</a>`;
     })
     .join('');
   const langSwitcher = renderLanguageSwitcher(locale, opts);
@@ -53,20 +53,46 @@ export function layout(
   <title>${escapeHtml(title)} · Think-Prompt</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
-    tailwind.config = { theme: { extend: { colors: {
-      good: '#22c55e', ok: '#eab308', weak: '#f97316', bad: '#ef4444'
-    }}}};
+    // Shared brand tokens — mirrors site/index.html so the marketing page and
+    // the local dashboard read as the same product. See D-037.
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            ink: '#0b0d12',
+            accent: '#6366f1',
+            good: '#22c55e', ok: '#eab308', weak: '#f97316', bad: '#ef4444'
+          },
+          fontFamily: {
+            sans: ['-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Inter', 'sans-serif'],
+            mono: ['ui-monospace', 'SF Mono', 'Menlo', 'Monaco', 'monospace']
+          }
+        }
+      }
+    };
   </script>
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+      font-feature-settings: "ss01", "cv11";
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
     pre { white-space: pre-wrap; word-break: break-word; }
+    :focus-visible {
+      outline: 2px solid #6366f1;
+      outline-offset: 3px;
+      border-radius: 4px;
+    }
   </style>
 </head>
 <body class="bg-gray-50 dark:bg-zinc-900 dark:text-zinc-100 min-h-screen">
-  <header class="bg-white dark:bg-zinc-800 border-b border-gray-200 dark:border-zinc-700">
+  <header class="bg-white dark:bg-zinc-800 border-b border-gray-100 dark:border-zinc-700">
     <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
       <div class="flex items-center gap-6">
-        <a href="${appendLangParam('/', locale)}" class="text-xl font-bold">Think-Prompt</a>
+        <a href="${appendLangParam('/', locale)}" class="flex items-center gap-2 text-xl font-bold">
+          <span class="inline-block w-2 h-2 rounded-full bg-accent"></span>Think-Prompt
+        </a>
         <nav class="text-sm flex gap-4 text-gray-600 dark:text-zinc-300">
           ${navHtml}
         </nav>
@@ -366,7 +392,7 @@ export function renderDeepAnalysisSection(
           <form method="POST" action="/settings/consent" style="display:inline">
             <input type="hidden" name="decision" value="grant" />
             <input type="hidden" name="return_to" value="/prompts/${safeId}?lang=${locale}" />
-            <button class="px-3 py-1 rounded bg-blue-600 text-white text-xs hover:bg-blue-700">${escapeHtml(t(locale, 'analysis.consent_grant'))}</button>
+            <button class="px-3 py-1 rounded bg-accent text-white text-xs hover:bg-accent/90 transition-colors">${escapeHtml(t(locale, 'analysis.consent_grant'))}</button>
           </form>
           <form method="POST" action="/settings/consent" style="display:inline">
             <input type="hidden" name="decision" value="revoke" />
@@ -382,7 +408,7 @@ export function renderDeepAnalysisSection(
         <form method="POST" action="/settings/consent" class="inline ml-2">
           <input type="hidden" name="decision" value="grant" />
           <input type="hidden" name="return_to" value="/prompts/${safeId}?lang=${locale}" />
-          <button class="underline hover:text-blue-600">${escapeHtml(t(locale, 'analysis.consent_change'))}</button>
+          <button class="underline hover:text-accent transition-colors">${escapeHtml(t(locale, 'analysis.consent_change'))}</button>
         </form>
       </div>`;
   }
@@ -454,7 +480,7 @@ function renderDeepAnalysisCard(a: DeepAnalysisViewRow, locale: Locale): string 
       : '';
 
   return `
-    <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4 border-l-4 border-purple-500">
+    <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4 border-l-4 border-l-accent">
       <div class="flex items-center justify-between mb-3">
         <div class="text-xs text-gray-500">
           ${escapeHtml(a.model)} · ${escapeHtml(a.created_at)}

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -197,7 +197,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       const href = `/?lang=${locale}&days=${encodeURIComponent(value)}`;
       const active = value === selectedPeriod;
       const base = 'px-2 py-1 text-xs rounded border transition-colors';
-      const activeCls = 'bg-blue-600 text-white border-blue-600';
+      const activeCls = 'bg-accent text-white border-accent';
       const inactiveCls =
         'bg-white dark:bg-zinc-800 text-gray-600 dark:text-zinc-300 border-gray-300 dark:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-700';
       return `<a href="${href}" class="${base} ${active ? activeCls : inactiveCls}">${escapeHtml(label)}</a>`;
@@ -238,12 +238,12 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     const body = `
       <h1 class="text-2xl font-bold mb-6">${escapeHtml(t(locale, 'overview.title'))}</h1>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-        <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-5">
+        <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-5">
           <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'overview.total_prompts'))}</div>
           <div class="text-3xl font-mono mt-2">${totals.c}</div>
           <div class="text-xs text-gray-400 mt-1">${escapeHtml(t(locale, 'overview.last_n_days', { n: DAYS }))}: ${windowTotal}</div>
         </div>
-        <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-5">
+        <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-5">
           <div class="flex items-center justify-between mb-3">
             <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'overview.tier_breakdown'))}</div>
             <div class="text-xs text-gray-400">${escapeHtml(t(locale, 'common.total'))} <span class="font-mono">${tierTotal}</span></div>
@@ -260,7 +260,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
             <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'common.total'))} <span class="font-mono">${windowTotal}</span></div>
           </div>
         </div>
-        <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
+        <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4">
           ${chartHtml}
         </div>
       </section>
@@ -270,7 +270,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         ${
           worst.length === 0
             ? `<div class="text-gray-400 text-sm">${escapeHtml(t(locale, 'overview.no_scored_yet'))}</div>`
-            : `<div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700">${worst
+            : `<div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm divide-y divide-gray-100 dark:divide-zinc-700">${worst
                 .map(
                   (r) =>
                     `<a href="/prompts/${r.id}?lang=${locale}" class="flex items-center gap-4 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
@@ -285,7 +285,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
 
       <section>
         <h2 class="text-lg font-bold mb-3">${escapeHtml(t(locale, 'overview.recent'))}</h2>
-        <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700">
+        <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm divide-y divide-gray-100 dark:divide-zinc-700">
           ${recent
             .map(
               (r) =>
@@ -386,10 +386,10 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         </select>
         <input name="rule" placeholder="${escapeHtml(t(locale, 'prompts.rule_placeholder'))}" value="${escapeHtml(ruleFilter ?? '')}"
                class="border rounded px-2 py-1 bg-white dark:bg-zinc-800" />
-        <button class="px-3 py-1 bg-blue-600 text-white rounded">${escapeHtml(t(locale, 'prompts.filter'))}</button>
+        <button class="px-3 py-1 bg-accent text-white rounded hover:bg-accent/90 transition-colors">${escapeHtml(t(locale, 'prompts.filter'))}</button>
         <a href="/prompts?lang=${locale}" class="px-3 py-1 text-gray-500">${escapeHtml(t(locale, 'prompts.clear'))}</a>
       </form>
-      <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-lg shadow overflow-hidden">
+      <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm overflow-hidden">
         <thead class="bg-gray-100 dark:bg-zinc-700 text-left">
           <tr>
             <th class="p-2 w-16">${escapeHtml(t(locale, 'prompts.col.score'))}</th>
@@ -478,7 +478,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     const analyzeEnabled = currentConfig.llm.enabled && consentState === 'granted';
 
     const body = `
-      <div class="mb-3"><a href="/prompts?lang=${locale}" class="text-blue-600 text-sm">${escapeHtml(t(locale, 'common.back'))}</a></div>
+      <div class="mb-3"><a href="/prompts?lang=${locale}" class="text-accent text-sm hover:underline">${escapeHtml(t(locale, 'common.back'))}</a></div>
       <h1 class="text-2xl font-bold mb-2">${escapeHtml(t(locale, 'detail.title'))} ${escapeHtml(u.id.slice(-8))}</h1>
       <div class="text-xs text-gray-500 mb-4">
         ${escapeHtml(t(locale, 'detail.session'))} <a class="underline" href="/sessions/${u.session_id}?lang=${locale}">${escapeHtml(u.session_id)}</a>
@@ -501,11 +501,11 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-        <div class="md:col-span-2 bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
+        <div class="md:col-span-2 bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4">
           <div class="text-xs text-gray-500 mb-2">${escapeHtml(t(locale, 'detail.original'))}</div>
           <pre class="text-sm">${escapeHtml(u.prompt_text)}</pre>
         </div>
-        <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
+        <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4">
           <div class="text-xs text-gray-500 mb-3">${escapeHtml(t(locale, 'detail.score'))}</div>
           ${
             score
@@ -522,7 +522,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       </div>
 
       <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'detail.rule_hits'))}</h2>
-      <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
+      <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
         ${
           hits.length === 0
             ? `<div class="p-3 text-sm text-gray-400">${escapeHtml(t(locale, 'detail.no_hits'))}</div>`
@@ -547,7 +547,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
             : rewrites
                 .map(
                   (r) =>
-                    `<div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
+                    `<div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4">
                        <div class="text-xs text-gray-500 mb-2">${escapeHtml(r.status)} · ${escapeHtml(r.created_at)}</div>
                        <pre class="text-sm">${escapeHtml(r.after_text)}</pre>
                        ${r.reason ? `<div class="mt-2 text-xs text-gray-500 italic">${escapeHtml(r.reason)}</div>` : ''}
@@ -621,7 +621,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       </div>
 
       <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'session.turns'))}</h2>
-      <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
+      <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
         ${usages
           .map(
             (u) =>
@@ -636,7 +636,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       </div>
 
       <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'session.subagents'))} (${subs.length})</h2>
-      <div class="bg-white dark:bg-zinc-800 rounded-lg shadow divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
+      <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm divide-y divide-gray-100 dark:divide-zinc-700 mb-6">
         ${
           subs.length === 0
             ? `<div class="p-3 text-sm text-gray-400">${escapeHtml(t(locale, 'session.none'))}</div>`
@@ -654,7 +654,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       </div>
 
       <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'session.tool_rollup'))}</h2>
-      <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-lg shadow overflow-hidden">
+      <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm overflow-hidden">
         <thead class="bg-gray-100 dark:bg-zinc-700 text-left">
           <tr>
             <th class="p-2">${escapeHtml(t(locale, 'session.col.tool'))}</th>
@@ -694,7 +694,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     const hitMap = Object.fromEntries(hitStats.map((h) => [h.rule_id, h.c]));
     const body = `
       <h1 class="text-2xl font-bold mb-4">${escapeHtml(t(locale, 'rules.title'))}</h1>
-      <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-lg shadow overflow-hidden">
+      <table class="w-full text-sm bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm overflow-hidden">
         <thead class="bg-gray-100 dark:bg-zinc-700 text-left">
           <tr>
             <th class="p-2 w-16">${escapeHtml(t(locale, 'rules.col.id'))}</th>
@@ -772,7 +772,7 @@ think-prompt coach on</pre>
     };
     const body = `
       <h1 class="text-2xl font-bold mb-4">${escapeHtml(t(locale, 'doctor.title'))}</h1>
-      <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4 mb-4">
+      <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4 mb-4">
         <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'doctor.counts'))}</h2>
         <ul class="text-sm space-y-1">
           <li>prompt_usages: ${counts.usages}</li>
@@ -782,7 +782,7 @@ think-prompt coach on</pre>
           <li>rewrites: ${counts.rewrites}</li>
         </ul>
       </div>
-      <div class="bg-white dark:bg-zinc-800 rounded-lg shadow p-4">
+      <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4">
         <h2 class="font-bold mb-2">${escapeHtml(t(locale, 'doctor.installed'))}</h2>
         <p class="text-sm text-gray-500">${escapeHtml(agentPid?.value ?? 'unknown')}</p>
       </div>`;

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -169,8 +169,8 @@ describe('dashboard period selector (?days=)', () => {
     const res = await app.inject({ method: 'GET', url: '/?lang=en' });
     expect(res.statusCode).toBe(200);
     // The 30d pill should be the one marked active (blue bg), 7d should be inactive.
-    expect(res.body).toMatch(/<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/);
-    expect(res.body).not.toMatch(/<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/);
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=30"[^>]*bg-accent[^>]*>30d<\/a>/);
+    expect(res.body).not.toMatch(/<a href="\/\?lang=en&days=7"[^>]*bg-accent[^>]*>7d<\/a>/);
     await app.close();
   });
 
@@ -178,7 +178,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=7' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(/<a href="\/\?lang=en&days=7"[^>]*bg-blue-600[^>]*>7d<\/a>/);
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=7"[^>]*bg-accent[^>]*>7d<\/a>/);
     await app.close();
   });
 
@@ -186,7 +186,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=90' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(/<a href="\/\?lang=en&days=90"[^>]*bg-blue-600[^>]*>90d<\/a>/);
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=90"[^>]*bg-accent[^>]*>90d<\/a>/);
     await app.close();
   });
 
@@ -194,7 +194,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=365' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(/<a href="\/\?lang=en&days=365"[^>]*bg-blue-600[^>]*>365d<\/a>/);
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=365"[^>]*bg-accent[^>]*>365d<\/a>/);
     await app.close();
   });
 
@@ -207,7 +207,7 @@ describe('dashboard period selector (?days=)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en&days=all' });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(/<a href="\/\?lang=en&days=all"[^>]*bg-blue-600[^>]*>all<\/a>/);
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=all"[^>]*bg-accent[^>]*>all<\/a>/);
     await app.close();
   });
 
@@ -218,7 +218,7 @@ describe('dashboard period selector (?days=)', () => {
       url: '/?lang=en&days=not-a-number',
     });
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatch(/<a href="\/\?lang=en&days=30"[^>]*bg-blue-600[^>]*>30d<\/a>/);
+    expect(res.body).toMatch(/<a href="\/\?lang=en&days=30"[^>]*bg-accent[^>]*>30d<\/a>/);
     await app.close();
   });
 
@@ -240,6 +240,50 @@ describe('dashboard period selector (?days=)', () => {
     const res = await app.inject({ method: 'GET', url: '/?lang=ko&days=all' });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('>전체<');
+    await app.close();
+  });
+});
+
+// Brand alignment with site/index.html — shared ink/accent tokens, Inter-ready
+// font stack, focus ring, logo dot. See D-037.
+describe('dashboard brand tokens', () => {
+  it("exposes ink and accent colors in the page's Tailwind config", async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain("ink: '#0b0d12'");
+    expect(res.body).toContain("accent: '#6366f1'");
+    await app.close();
+  });
+
+  it('declares the sans + mono font family extension to match the site', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.body).toContain('Inter');
+    expect(res.body).toContain("'SF Mono'");
+    await app.close();
+  });
+
+  it('uses an accent-coloured focus ring for keyboard users', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.body).toMatch(/:focus-visible[\s\S]{0,80}#6366f1/);
+    await app.close();
+  });
+
+  it('puts an accent dot before the Think-Prompt logo wordmark', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.body).toMatch(/<span class="inline-block w-2 h-2 rounded-full bg-accent"><\/span>Think-Prompt/);
+    await app.close();
+  });
+
+  it('no longer uses raw Tailwind blue-6xx anywhere in the rendered chrome', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    for (const url of ['/?lang=en', '/prompts?lang=en', '/doctor?lang=en']) {
+      const res = await app.inject({ method: 'GET', url });
+      expect(res.body).not.toMatch(/\b(bg|text|border|hover:bg|hover:text)-blue-\d/);
+    }
     await app.close();
   });
 });

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -274,7 +274,9 @@ describe('dashboard brand tokens', () => {
   it('puts an accent dot before the Think-Prompt logo wordmark', async () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en' });
-    expect(res.body).toMatch(/<span class="inline-block w-2 h-2 rounded-full bg-accent"><\/span>Think-Prompt/);
+    expect(res.body).toMatch(
+      /<span class="inline-block w-2 h-2 rounded-full bg-accent"><\/span>Think-Prompt/
+    );
     await app.close();
   });
 

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/rules",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Think-Prompt antipattern rule catalog (R001..R018+) with positive/negative samples",
   "type": "module",
   "license": "MIT",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/worker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Think-Prompt background worker: transcript parsing, LLM judge, rewriter",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## 요약 / Summary

랜딩(`site/index.html`) 과 로컬 대시보드가 **같은 프로덕트라는 시각적 신호**를 확보. 색(`ink`·`accent`), 폰트(Inter cascade), 포커스 링, 카드 톤, 로고 도트를 사이트와 일치시킨다. D-012(번들러 없음) 철학 유지 — Tailwind CDN 인라인 config 만 확장.

Unify the brand signals between the marketing site and the local
dashboard: ink/accent colors, Inter + SF Mono cascade, accent focus
ring, card tone, logo dot. Keep D-012 (no bundler) — only the inline
Tailwind CDN config is extended.

## 변경 요약 / Scope

| Phase | 내용 | 파일 |
|---|---|---|
| **1. 토큰** | `ink: #0b0d12` · `accent: #6366f1` · `fontFamily.sans`/`mono` extend | html.ts |
| **2. accent 스왑** | `blue-6xx` → `accent` (네비·pill·버튼·back링크·consent 버튼) 6곳 | html.ts, server.ts |
| **3. 스타일 시트** | `:focus-visible` accent ring + `font-feature-settings: "ss01","cv11"` + Inter 추가 | html.ts |
| **4. 카드 톤** | `rounded-lg shadow` → `rounded-xl border border-gray-200 shadow-sm` 16건 + 좌측바 `border-purple-500` → `border-l-accent` | server.ts, html.ts |
| **5. 마이크로 브랜딩** | 로고 앞 accent 도트, 네비 `transition-colors` | html.ts |

## 의도적으로 보존 / Intentionally kept different

- `max-w-6xl` (사이트 5xl 대비 더 넓음) — 데이터 밀도
- h1/h2 작은 사이즈 (`text-2xl` / `text-lg`) — 사이트는 마케팅 히어로
- 다크모드 팔레트 — 사이트는 라이트 전용
- 사이트를 그대로 복제하면 대시보드가 보기 좋지만 비효율적인 화면이 됨

## 테스트 / Tests

- [x] `pnpm -F @think-prompt/dashboard exec vitest run` — **45/45 pass** (40 → 45)
  - 신규: `exposes ink and accent colors`
  - 신규: `declares the sans + mono font family extension`
  - 신규: `uses an accent-coloured focus ring`
  - 신규: `puts an accent dot before the Think-Prompt logo`
  - 신규: `no longer uses raw Tailwind blue-6xx anywhere in the rendered chrome` (overview·prompts·doctor 3 페이지 동시 검증)
- [x] 기존 `bg-blue-600` 매치 7건 → `bg-accent` 업데이트
- [x] `pnpm typecheck` — 7/7 pass
- [x] 47824 라이브 실측:
  - 브랜드 마커 6개(`ink`·`accent`·`bg-accent`·`hover:text-accent`·로고 도트·focus-visible) 전부 응답 HTML 에 포함
  - `bg-blue-*` · `text-blue-*` · `border-blue-*` · `hover:*-blue-*` 0건
  - pill active: `bg-accent text-white`
- [ ] 리뷰어: 브라우저에서 네비 hover 색상, 기간 선택 pill, `/prompts` 필터 버튼, `/prompts/:id` back 링크, 로고 앞 indigo 도트 시각 확인

## Before / After 브랜드 토큰 비교

| 항목 | Before | After |
|---|---|---|
| accent 색 | `blue-600` (#2563eb) | **`accent` (#6366f1)** |
| ink 토큰 | 없음 | **`#0b0d12`** |
| 폰트 cascade | system sans | system sans + **Inter + SF Mono** |
| 포커스 링 | Tailwind 기본 | **accent 2px + offset 3px** |
| 카드 | `rounded-lg shadow` | **`rounded-xl border shadow-sm`** |
| 로고 | 플레인 텍스트 | **accent 도트 + wordmark** |

## 브랜치 / Base

두 커밋 순서:
1. `e369867` — D-036 (Rules nav 숨김, PR #29)
2. `765647f` — **D-037 (이번 PR)**

PR #29 먼저 머지되면 이 PR 은 1-commit diff 로 자동 정리됨.