### PR TITLE
fix(agent): post-tool-use 훅이 세션 미지 상태에서 FK 위반 / upsert session before bumping tool rollup (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ stability guarantees of v1.0 do not yet apply.
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Fixed
+- **agent `/v1/hook/post-tool-use`** now upserts the session row before
+  bumping the tool-use rollup. Previously, if `PostToolUse` fired for a
+  session that had not yet produced a `SessionStart` / `UserPromptSubmit`
+  (e.g. hooks installed mid-session), the `tool_use_rollups.session_id`
+  foreign key constraint failed and the event was dropped. Fail-open
+  swallowed the error, so this was invisible to users but silently
+  under-counted tool rollups for that session. Matches the upsert
+  pattern already used by the other five hook handlers. Fixes #11.
 
 ---
 

--- a/docs/99-observation-log.md
+++ b/docs/99-observation-log.md
@@ -48,3 +48,24 @@
 - 01-hook-design §9: HTTP type 훅 6종 라우팅 정상 동작 확정
 
 **미해결:** O-002, O-004(가정대로 작동 중이지만 직접 JSONL 키 검증 별도 필요), O-006, O-008, O-009, O-010 — 모두 사용자가 특정 시나리오를 만들어야 검증 가능 (compact / resume / 인위적 timeout / Claude 답변 비교 실험).
+
+---
+
+### 2026-04-23 · PostToolUse 가 세션 미지 상태에서 FK 위반 (fail-open 은폐)
+
+**Source:** Issue #11 dogfooding 재현 — `~/.think-prompt/agent.log` 에 `SqliteError: FOREIGN KEY constraint failed` (`code: SQLITE_CONSTRAINT_FOREIGNKEY`, `msg: "post-tool-use failed"`).
+
+**Observed:**
+- Claude Code 세션을 먼저 띄운 뒤 별개 터미널에서 `think-prompt install` 을 실행하는 시나리오에서는, 이미 러닝 중인 세션의 `SessionStart` / `UserPromptSubmit` 이 우리 agent 에 도달하지 않고 이후 `PostToolUse` 만 도달한다.
+- `/v1/hook/post-tool-use` 핸들러는 `sessions` 행이 없는 상태에서 `bumpToolRollup` 을 호출 → `tool_use_rollups.session_id REFERENCES sessions(id)` FK 위반 → 500. `config.agent.fail_open` 가 빈 `{}` 로 덮어 Claude Code 자체는 영향 없음.
+- 결과: 해당 세션의 `tool_use_rollups` 가 **조용히** 누락 (집계 정확도 저하).
+
+**Why the other five hooks did not hit this:** `user-prompt-submit`, `session-start`, `subagent-start`, `subagent-stop`, `stop` 핸들러는 모두 본문 처리 전 `upsertSession(db, { id, cwd })` 를 호출해 sessions 행을 멱등 upsert. `post-tool-use` 만 이 패턴이 빠져 있었음 (`packages/agent/src/server.ts:253`).
+
+**Doc impact:**
+- 01-hook-design §1: "매 hook 핸들러는 본문 처리 전 `upsertSession` 선행" 규약을 명시 고려.
+- `CHANGELOG.md` `[Unreleased] / Fixed` 에 반영.
+
+**Fix:** `packages/agent/src/server.ts` 에 `upsertSession` 1줄 선행 호출 + 회귀 테스트 `post-tool-use upserts unknown session (FK-safe, regression for #11)` 추가. PR `fix/post-tool-use-fk-session` 참조.
+
+**Residual:** fail-open 가 이런 silent drop 을 은폐하는 구조는 D-028 의도대로이지만, 에이전트 내부 에러 카운터를 `think-prompt doctor` 에서 노출하는 후속 작업을 고려할 수 있음 (별도 이슈 후보).

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -253,6 +253,7 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
   fastify.post('/v1/hook/post-tool-use', async (req) => {
     try {
       const p = PostToolUsePayload.parse(req.body);
+      upsertSession(db, { id: p.session_id, cwd: p.cwd ?? '/' });
       const inputSize = JSON.stringify(p.tool_input ?? '').length;
       const outputSize = JSON.stringify(p.tool_response ?? '').length;
       bumpToolRollup(db, {

--- a/packages/agent/test/server.test.ts
+++ b/packages/agent/test/server.test.ts
@@ -177,6 +177,37 @@ describe('agent server', () => {
     await app.close();
   });
 
+  it('post-tool-use upserts unknown session (FK-safe, regression for #11)', async () => {
+    const { openDb } = await import('@think-prompt/core');
+    const app = buildAgentServer({ rootOverride: tmp });
+    // Simulate PostToolUse arriving before SessionStart / UserPromptSubmit:
+    // the sessions row does not exist yet, which used to trip the
+    // FOREIGN KEY constraint on tool_use_rollups.session_id.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/hook/post-tool-use',
+      payload: {
+        session_id: 'ptu-unknown-session',
+        cwd: '/tmp',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hi' },
+        tool_response: 'hi',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+    const db = openDb(tmp);
+    const session = db.prepare(`SELECT id FROM sessions WHERE id = ?`).get('ptu-unknown-session') as
+      | { id: string }
+      | undefined;
+    expect(session?.id).toBe('ptu-unknown-session');
+    const rollup = db
+      .prepare(`SELECT call_count FROM tool_use_rollups WHERE session_id = ? AND tool_name = ?`)
+      .get('ptu-unknown-session', 'Bash') as { call_count: number } | undefined;
+    expect(rollup?.call_count).toBe(1);
+    db.close();
+  });
+
   it('subagent-stop enqueues parse job', async () => {
     const app = buildAgentServer({ rootOverride: tmp });
     const res = await app.inject({


### PR DESCRIPTION
## Summary

`PostToolUse` 훅이 `SessionStart` / `UserPromptSubmit` 보다 먼저 도달하는 시나리오(예: Claude Code 세션이 이미 러닝 중인 상태에서 `think-prompt install` 실행)에서, `/v1/hook/post-tool-use` 핸들러가 `sessions` 행이 존재하지 않는 `session_id` 로 곧장 `bumpToolRollup` 을 호출하여 `tool_use_rollups.session_id REFERENCES sessions(id)` FK 위반이 발생했다. `fail_open` 덕분에 Claude Code 자체에는 영향이 없었지만 해당 세션의 tool rollup 집계가 **조용히** 누락됐다.

다른 5개 훅 핸들러(`user-prompt-submit`, `session-start`, `subagent-start`, `subagent-stop`, `stop`)는 본문 처리 전 `upsertSession(db, { id, cwd })` 를 선행 호출하고 있었음. `post-tool-use` 만 이 패턴이 빠져있었고, 이슈 #11 의 Option A (권장안) 가 제안한 3줄 수술로 해결.

Fixes #11.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor (no behaviour change)
- [ ] CI / tooling
- [ ] Breaking change

## Affected packages

- [ ] `@think-prompt/core`
- [ ] `@think-prompt/rules`
- [x] `@think-prompt/agent`
- [ ] `@think-prompt/worker`
- [ ] `@think-prompt/dashboard`
- [ ] `@think-prompt/cli`
- [x] `docs/` — `docs/99-observation-log.md` 에 실측 기록 append

## Decision log

N/A — 기존 5개 훅 핸들러의 `upsertSession` 패턴을 `post-tool-use` 에 동일 적용하는 일관화 수정. 스키마/FK 자체를 건드리지 않으므로 D-NNN append 불필요.

## Testing

- [x] `pnpm run ci` passes locally (23 파일 · 205 tests · 이전 204 + 회귀 테스트 1건 추가)
- [x] Added or updated tests — `post-tool-use upserts unknown session (FK-safe, regression for #11)`
- [x] Updated `CHANGELOG.md` under `[Unreleased] / Fixed`

### 수동 검증 명령

\`\`\`bash
pnpm -F @think-prompt/agent test -- --run
# Test Files  1 passed (1)
#      Tests  12 passed (12)
\`\`\`

## Screenshots / output

해당 없음 — 백엔드 수정. fail-open 이 계속 동작하므로 외부 가시 동작은 변하지 않고, 내부적으로 tool rollup 집계 누락만 제거됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)