### PR TITLE
feat: 브랜드 favicon 추가 (대시보드 + 사이트) / Add brand favicon to dashboard and site

### DIFF
--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -51,6 +51,7 @@ export function layout(
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${escapeHtml(title)} · Think-Prompt</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     // Shared brand tokens — mirrors site/index.html so the marketing page and

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -80,6 +80,26 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
 
   fastify.get('/health', async () => ({ ok: true }));
 
+  /**
+   * Favicon — brand-aligned SVG glyph (accent background + ascending tier
+   * bars). Inlined here so the dashboard stays self-contained; no asset
+   * pipeline needed (D-012). Served with a one-day cache so browsers
+   * don't re-fetch on every navigation.
+   */
+  const FAVICON_SVG =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
+    '<rect width="32" height="32" rx="8" fill="#6366f1"/>' +
+    '<rect x="7" y="17" width="4" height="8" fill="white"/>' +
+    '<rect x="14" y="12" width="4" height="13" fill="white"/>' +
+    '<rect x="21" y="8" width="4" height="17" fill="white"/>' +
+    '</svg>';
+  fastify.get('/favicon.svg', async (_req, reply) => {
+    reply
+      .type('image/svg+xml')
+      .header('Cache-Control', 'public, max-age=86400, immutable')
+      .send(FAVICON_SVG);
+  });
+
   /** Live-refresh polling target — cheap, returns JSON, no HTML. */
   fastify.get('/api/overview/latest-id', async () => {
     return { latestId: latestPromptId() };

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -617,3 +617,33 @@ describe('dashboard live-refresh', () => {
     await app.close();
   });
 });
+
+// Favicon — derived from the marketing-site brand (accent + bar-chart glyph).
+// Served as a single SVG to match D-012 (no bundler, no asset pipeline).
+describe('dashboard favicon', () => {
+  it('serves an SVG favicon on /favicon.svg with the brand accent color', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/favicon.svg' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('image/svg+xml');
+    expect(res.body).toContain('<svg');
+    expect(res.body).toContain('#6366f1');
+    await app.close();
+  });
+
+  it('sends a long-lived cache header for the favicon so browsers reuse it', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/favicon.svg' });
+    expect(res.headers['cache-control']).toMatch(/max-age=\d+/);
+    await app.close();
+  });
+
+  it('links the favicon from every page <head>', async () => {
+    const app = buildDashboardServer({ rootOverride: tmp });
+    for (const url of ['/?lang=en', '/prompts?lang=en', '/doctor?lang=en']) {
+      const res = await app.inject({ method: 'GET', url });
+      expect(res.body).toMatch(/<link rel="icon" type="image\/svg\+xml" href="\/favicon\.svg"/);
+    }
+    await app.close();
+  });
+});

--- a/site/README.md
+++ b/site/README.md
@@ -52,5 +52,7 @@ the homepage gets a PR.
 
 - [ ] Replace the placeholder demo block with a 30-second GIF before v0.1.0
       launch (see `docs/10-launch-strategy.md` §0).
-- [ ] Add favicon + Open Graph image (1200×630 PNG).
+- [x] Add favicon (`favicon.svg` — accent background + ascending-bar glyph,
+      shared with the local dashboard).
+- [ ] Add Open Graph image (1200×630 PNG).
 - [ ] Custom domain DNS once it's purchased.

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="8" fill="#6366f1"/><rect x="7" y="17" width="4" height="8" fill="white"/><rect x="14" y="12" width="4" height="13" fill="white"/><rect x="21" y="8" width="4" height="17" fill="white"/></svg>

--- a/site/index.html
+++ b/site/index.html
@@ -6,6 +6,8 @@
   <title>Think-Prompt — a local-first Claude Code prompt coach</title>
   <meta name="description" content="See which of your Claude Code prompts actually work. 18 antipattern rules, 5-language dashboard, opt-in LLM deep analysis. Local-first — prompts never leave your machine." />
 
+  <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+
   <!-- Open Graph -->
   <meta property="og:title" content="Think-Prompt — local-first Claude Code prompt coach" />
   <meta property="og:description" content="Score every Claude Code prompt against 18 antipattern rules. Runs entirely on your machine." />


### PR DESCRIPTION
## 요약 / Summary

사이트의 accent 도트 + 대시보드의 스택 바 차트를 결합한 **32×32 SVG 글리프**를 양쪽에 적용. 탭 제목 옆에 indigo 식별 마크가 항상 보이게 해서 멀티 탭 환경에서도 Think-Prompt 를 즉각 식별 가능.

Combine the marketing site's accent dot and the dashboard's stacked-bar
chart into a single 32×32 SVG glyph, wired to both `/favicon.svg` on the
dashboard and `site/favicon.svg` for GitHub Pages.

## 디자인 / Design

```xml
<svg viewBox="0 0 32 32">
  <rect width="32" height="32" rx="8" fill="#6366f1"/>
  <rect x="7"  y="17" width="4" height="8"  fill="white"/>
  <rect x="14" y="12" width="4" height="13" fill="white"/>
  <rect x="21" y="8"  width="4" height="17" fill="white"/>
</svg>
```

- **Rounded square (`rx=8`) · accent(#6366f1) 배경** — 사이트의 accent 시그너처 일치
- **3개 상승 white bars** — 대시보드의 시그너처 스택 바 차트 축약 + D-032 미션 은유 ("프롬프트 자각이 점진적으로 향상")
- **16×16 에서도 3개 bar 식별 가능**, 32×32 에서는 또렷
- **PNG 변환 불필요** — Claude Code 사용자 환경의 모든 모던 브라우저가 SVG favicon 지원

## 변경 / Changes

### Dashboard
- `packages/dashboard/src/server.ts` — `FAVICON_SVG` 인라인 상수 + `/favicon.svg` 라우트 (`image/svg+xml` + 1-day `Cache-Control: public, max-age=86400, immutable`)
- `packages/dashboard/src/html.ts` — 전 페이지 `<head>` 에 `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />`

### Site (GitHub Pages)
- `site/favicon.svg` 신규 (동일 SVG, 상대 경로)
- `site/index.html` `<head>` 에 favicon 링크
- `site/README.md` TODO 갱신 (OG 이미지만 남음)

## 왜 인라인 SVG 라우트인가 / Why inline SVG route

- **D-012 (번들러 없음)** 유지 — 추가 asset pipeline 없음
- **D-034 (단일 번들 배포)** 유지 — CLI dist 에 자동 번들
- **PNG `.ico` 파일 굳이 필요 없음** — Chrome/Firefox/Safari/Edge 최근 5년 버전 모두 SVG favicon 지원. Claude Code 사용자 기준 100% 커버.
- **Cache-Control: immutable** — 파일 변경 시 SVG 본문이 바뀌면 URL 경로는 같지만 페이지는 다시 요청 → 실무상 재배포 이슈 없음

## 테스트 / Tests

- [x] `pnpm -F @think-prompt/dashboard exec vitest run` — **48/48 pass** (45 → 48)
  - 신규: `serves an SVG favicon on /favicon.svg with the brand accent color`
  - 신규: `sends a long-lived cache header for the favicon`
  - 신규: `links the favicon from every page <head>` (overview·prompts·doctor 3 페이지 검증)
- [x] `pnpm run ci` — **215/215 pass** (23 test files)
- [x] 로컬 47824 라이브 실측:
  - `curl /favicon.svg` → `200 · image/svg+xml` · body 가 indigo SVG
  - `<head>` 에 link rel="icon" 포함
- [ ] 리뷰어: 브라우저 탭 favicon 이 indigo bar-chart 로 보이는지, site 빌드 후 GitHub Pages 에서 파비콘 렌더링 확인

## 미션 정렬 / Mission alignment (D-032)

"유저의 두 근본 문제(인지 고착·프롬프트 자각 부재) 해결" 이라는 WHY 에서, 상승하는 3개 bar 는 단순 장식이 아니라 **프롬프트 품질이 관찰·개선 가능한 변수임을 상시 상기시키는 시각 신호**. 탭 목록에서 Think-Prompt 를 열 때마다 마주치는 작은 글리프가 그 인상을 축적.