### PR TITLE
feat(dashboard): Overview KPI 행 개편 — Total + 5 tier tile / Overview KPI row — Total + 5 tier tiles

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -246,31 +246,60 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       )
       .all() as Array<{ id: string; snippet: string; final_score: number; tier: string }>;
 
-    const tierHtml = tierCounts
-      .map(
-        (tc) =>
-          `<div class="flex items-center gap-2"><span class="font-mono text-sm">${tc.c}</span>${tierBadge(tc.tier, locale)}</div>`
-      )
+    // Tier tiles — each tier gets its own card with a big mono number, matching
+    // the "Total prompts" card's visual weight so all 6 (Total + 5 tiers) scan
+    // as a single glanceable KPI row. Left color bar = tier identity; percentage
+    // subtitle gives share-of-total context without adding extra labels.
+    const TIER_TILE_STYLE: Record<string, { bar: string; num: string; label: string }> = {
+      good: {
+        bar: 'bg-green-500',
+        num: 'text-green-700 dark:text-green-300',
+        label: 'GOOD',
+      },
+      ok: {
+        bar: 'bg-yellow-500',
+        num: 'text-yellow-700 dark:text-yellow-300',
+        label: 'OK',
+      },
+      weak: {
+        bar: 'bg-orange-500',
+        num: 'text-orange-700 dark:text-orange-300',
+        label: 'WEAK',
+      },
+      bad: { bar: 'bg-red-500', num: 'text-red-700 dark:text-red-300', label: 'BAD' },
+      'n/a': {
+        bar: 'bg-gray-400',
+        num: 'text-gray-500 dark:text-zinc-400',
+        label: 'N/A',
+      },
+    };
+    const tierTilesHtml = tierCounts
+      .map((tc) => {
+        const pct = tierTotal > 0 ? Math.round((tc.c / tierTotal) * 100) : 0;
+        const style = TIER_TILE_STYLE[tc.tier] ?? TIER_TILE_STYLE['n/a'];
+        const styleObj = style ?? { bar: 'bg-gray-400', num: 'text-gray-500', label: 'N/A' };
+        return `
+          <div class="relative bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-5 overflow-hidden">
+            <div class="absolute left-0 top-0 h-full w-1 ${styleObj.bar}"></div>
+            <div class="text-[10px] text-gray-500 dark:text-zinc-400 uppercase tracking-widest font-mono font-semibold">${styleObj.label}</div>
+            <div class="text-3xl font-mono mt-2 ${styleObj.num}">${tc.c.toLocaleString()}</div>
+            <div class="text-xs text-gray-400 mt-1">${pct}%</div>
+          </div>`;
+      })
       .join('');
 
     const chartHtml = renderDailyChart(days);
 
     const body = `
       <h1 class="text-2xl font-bold mb-6">${escapeHtml(t(locale, 'overview.title'))}</h1>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+      <section aria-label="${escapeHtml(t(locale, 'overview.tier_breakdown'))}" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
         <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-5">
-          <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'overview.total_prompts'))}</div>
-          <div class="text-3xl font-mono mt-2">${totals.c}</div>
-          <div class="text-xs text-gray-400 mt-1">${escapeHtml(t(locale, 'overview.last_n_days', { n: DAYS }))}: ${windowTotal}</div>
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-mono font-semibold">${escapeHtml(t(locale, 'overview.total_prompts'))}</div>
+          <div class="text-3xl font-mono mt-2">${totals.c.toLocaleString()}</div>
+          <div class="text-xs text-gray-400 mt-1">${escapeHtml(t(locale, 'overview.last_n_days', { n: DAYS }))}: ${windowTotal.toLocaleString()}</div>
         </div>
-        <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-5">
-          <div class="flex items-center justify-between mb-3">
-            <div class="text-xs text-gray-500">${escapeHtml(t(locale, 'overview.tier_breakdown'))}</div>
-            <div class="text-xs text-gray-400">${escapeHtml(t(locale, 'common.total'))} <span class="font-mono">${tierTotal}</span></div>
-          </div>
-          <div class="flex gap-3 flex-wrap">${tierHtml}</div>
-        </div>
-      </div>
+        ${tierTilesHtml}
+      </section>
 
       <section class="mb-8">
         <div class="flex items-center justify-between mb-3 flex-wrap gap-2">

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -89,13 +89,50 @@ describe('dashboard', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/?lang=en' });
     expect(res.statusCode).toBe(200);
-    for (const tier of ['good', 'ok', 'weak', 'bad', 'n/a']) {
+    // Each tier now gets its own KPI tile with the uppercase ASCII label.
+    for (const tier of ['GOOD', 'OK', 'WEAK', 'BAD', 'N/A']) {
       expect(res.body).toContain(`>${tier}<`);
     }
+    // "Tier breakdown" label is preserved as an aria-label on the tile group
+    // (screen-reader accessible, visually implicit via the tier tiles).
     expect(res.body).toContain('Tier breakdown');
     // Coach mode card is permanently removed from Overview (was previously
     // a 3rd tile).
     expect(res.body).not.toContain('Coach mode');
+    await app.close();
+  });
+
+  it('overview renders Total + 5 tier tiles as one KPI row (big mono numbers)', async () => {
+    const db = openDb();
+    upsertSession(db, { id: 's-tiles', cwd: '/tmp' });
+    for (let i = 0; i < 3; i++) {
+      const u = insertPromptUsage(db, {
+        session_id: 's-tiles',
+        prompt_text: `p${i}`,
+      });
+      upsertQualityScore(db, {
+        usage_id: u.id,
+        rule_score: 80,
+        final_score: 80,
+        tier: 'good',
+        rules_version: 1,
+      });
+    }
+    db.close();
+
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/?lang=en' });
+    expect(res.statusCode).toBe(200);
+    // 6-card grid (Total + 5 tiers), each big-number mono tile.
+    expect(res.body).toMatch(/lg:grid-cols-6/);
+    // Total prompts tile has the big 3xl mono number.
+    expect(res.body).toMatch(/Total prompts[\s\S]{0,200}text-3xl font-mono[\s\S]{0,20}>3</);
+    // Each tier has its own tile with GOOD/OK/... label above a big number.
+    expect(res.body).toMatch(/>GOOD<\/div>[\s\S]{0,100}text-3xl font-mono[\s\S]{0,60}>3</);
+    // Each tile shows a percentage subtitle.
+    expect(res.body).toMatch(/>100%</);
+    // Tier-colored left bar appears per tile.
+    expect(res.body).toMatch(/absolute left-0 top-0 h-full w-1 bg-green-500/);
     await app.close();
   });
 


### PR DESCRIPTION
## 요약 / Summary

유저 요청: Tier breakdown 을 5개 영역으로 각각 나눠 **Total prompts 와 같은 큰 숫자 타일**로 보여달라.

Before:
```
┌──────────────┐  ┌──────────────────────────────┐
│ Total: 3691  │  │ Tier breakdown  total 3691  │
│              │  │ 628 GOOD  2919 OK  142 WEAK │
│              │  │ 2 BAD  0 N/A                │
└──────────────┘  └──────────────────────────────┘
```

After:
```
┌─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
│ Total   │ GOOD    │ OK      │ WEAK    │ BAD     │ N/A     │
│ 3,691   │ 628     │ 2,919   │ 142     │ 2       │ 0       │
│ l30:3404│ 17%     │ 79%     │ 3%      │ 0%      │ 0%      │
└─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
```

## 설계 / Design

각 타일 공통 구조:
- 좌측 `w-1 h-full` tier 컬러 바 (bg-green-500 / yellow-500 / orange-500 / red-500 / gray-400)
- `text-[10px] uppercase tracking-widest font-mono font-semibold` 상단 라벨
- `text-3xl font-mono` 빅 넘버 (tier 컬러 적용)
- `text-xs text-gray-400` 서브텍스트 (퍼센티지 또는 "last N days")

숫자는 `toLocaleString()` 로 천단위 콤마 처리.

## 반응형 그리드

```
grid-cols-2 md:grid-cols-3 lg:grid-cols-6
```

- **모바일** (≥ 640px): 2열 × 3행
- **태블릿** (≥ 768px): 3열 × 2행
- **데스크톱** (≥ 1024px): 6열 × 1행 (한 줄)

## 접근성 / Accessibility

"Tier breakdown" 섹션 이름은 `<section aria-label="Tier breakdown">` 으로 보존:
- 시각적으로: 타일 자체가 섹션임을 설명하므로 중복 헤더 불필요
- 스크린리더: 섹션 이름 여전히 전달
- i18n 테스트: `overview.tier_breakdown` 키가 5개 언어 모두 HTML 에 출현

## 테스트 / Tests

- [x] `pnpm -F @think-prompt/dashboard exec vitest run` — **48/48 pass** (47 → 48)
  - 신규: `overview renders Total + 5 tier tiles as one KPI row` — lg:grid-cols-6, 각 tile 빅 넘버, 퍼센티지, tier 컬러 바 동시 검증
  - 업데이트: 기존 `overview shows all 5 tier slots` 테스트 → 소문자 (`>good<`) 대신 대문자 ASCII (`>GOOD<`) 체크. 대문자 선택 근거는 PR #37 의 tierBadge 대문자 정책과 일관.
- [x] `pnpm run ci` — **217/217 pass** (23 test files)
- [x] 로컬 47824 라이브 실측:
  - 그리드 클래스 `lg:grid-cols-6` 응답에 포함
  - GOOD/OK/WEAK/BAD/N/A 라벨 모두 존재
  - 각 tier 컬러 바 (`bg-green-500`, `bg-yellow-500`, `bg-orange-500`, `bg-red-500`, `bg-gray-400`) 모두 렌더

## 의도적으로 유지 / Intentionally kept

- **Total prompts 의 서브텍스트**: "last N days: M" 유지 → 타 tier 타일의 "%" 와 의미가 달라서 구분 의도 (Total 은 절대 / Tier 는 상대)
- **tierBadge** 함수는 이 PR 에서 건드리지 않음 → 하단 "Lowest scoring" / "Recent" 리스트의 개별 row 배지는 기존 스타일 유지. PR #37 (emerald palette) 가 머지되면 자동으로 함께 강조됨.

## 브랜치 / Base

feat/overview-tier-tiles → main. PR #37 (D-038 emerald) 이 머지되기 전에 이 PR 이 먼저 머지되면 tier tile 의 컬러는 현재 tailwind green/yellow/orange/red-500 토큰 그대로. 이후 #37 머지 시 accent/ink 토큰이 함께 적용됨 (충돌 없음, 토큰명 충돌이 아닌 다른 유틸 클래스만 사용).