### PR TITLE
feat(dashboard): created_at 로케일별 현지 시간 렌더 (D-042) / Locale-aware created_at timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ stability guarantees of v1.0 do not yet apply.
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- **`created_at` timestamps are now shown in the locale's home timezone**
+  — Prompts table, Overview "Recent" list, and Detail meta all render
+  `YYYY-MM-DD HH:MM:SS` in:
+  `Asia/Seoul` (ko), `Asia/Tokyo` (ja), `Asia/Shanghai` (zh),
+  `America/New_York` (en, DST-aware), `Europe/Madrid` (es, DST-aware).
+  The DB still stores UTC ISO; conversion happens at render time via
+  `Intl.DateTimeFormat`. Raw `...T...Z` millisecond-precision strings no
+  longer surface in the UI. D-042.
 
 ---
 

--- a/docs/00-decision-log.md
+++ b/docs/00-decision-log.md
@@ -412,6 +412,35 @@
 
 ---
 
+## D-042 · Created 타임스탬프를 로케일별 IANA 타임존으로 렌더
+
+- **Date:** 2026-04-24
+- **Problem:** Prompts 테이블과 디테일 meta 의 `created_at` 이 DB 의 raw UTC ISO(`2026-06-15T03:30:45.000Z`) 그대로 노출. 유저(한국)는 "UTC 라 시차 헷갈리고 밀리초·Z suffix 노이즈" 를 지적. "언어에 따라 현지 시간으로" 를 요청.
+- **Decision:**
+  - **DB 저장은 UTC ISO 유지** — 로케일 변경해도 row 재작성 불필요.
+  - **UI 렌더 시점**에 `Intl.DateTimeFormat('en-CA', { timeZone, hour12: false, ... })` 로 `YYYY-MM-DD HH:MM:SS` 생성.
+  - **로케일 → IANA 타임존** 매핑:
+    - `ko` → `Asia/Seoul` (UTC+9)
+    - `ja` → `Asia/Tokyo` (UTC+9)
+    - `zh` → `Asia/Shanghai` (UTC+8)
+    - `en` → `America/New_York` (UTC-5/-4, DST)
+    - `es` → `Europe/Madrid` (UTC+1/+2, DST)
+  - **fixed offset 대신 IANA 이름** 사용 — DST 가 있는 en·es 에서 연중 자동 조정.
+  - 포맷 헬퍼는 `packages/dashboard/src/i18n.ts` 에 `formatLocalDateTime(iso, locale)` 로 노출 → Prompts 테이블, Overview Recent 리스트, Detail meta 3 곳에서 동일 함수 사용.
+- **Rationale:**
+  - "한국 유저는 +9, 중국은 +8, …" 의 고정 오프셋으로 구현하면 en(ET)·es(Madrid) 가 DST 전환(3월·11월) 시 1시간 어긋남. `Intl` + IANA 이름은 브라우저/Node 의 tzdata 로 무상 해결.
+  - `en-CA` 포맷 로케일은 YYYY-MM-DD 순서를 내장 — 파트를 수동 재조립하는 비용 없음.
+- **Scope:**
+  - `packages/dashboard/src/i18n.ts`: `TIMEZONE_BY_LOCALE` 맵 + `formatLocalDateTime` 함수 신규.
+  - `packages/dashboard/src/server.ts`: Prompts 테이블 `Created` 셀, Overview Recent 의 `<span>`, Detail `<details>` meta 의 `created_at` 을 모두 `formatLocalDateTime` 으로 교체.
+  - 테스트 6건 추가 (5개 로케일 각 변환 + raw UTC 미노출 회귀).
+- **Known limits:**
+  - en 이 `America/New_York` 로 고정 — 실제 en 유저가 LA/Chicago 거주 시 여전히 ET 로 표시. 개별 유저 타임존 오버라이드(config) 는 후속 과제.
+  - es 가 `Europe/Madrid` 로 고정 — Canary Islands(`Atlantic/Canary`) 유저는 1 시간 오차. 소수 케이스, 후속.
+- **관계:** D-032(미션) — "유저가 자기 프롬프트를 돌아보는" 흐름에서 시간이 즉각 읽혀야 인지 마찰 감소.
+
+---
+
 ## 취소된 결정
 
 ### D-026 · 자동 리라이트 전략 (단일 버전 메타 프롬프트 · accept/reject)

--- a/packages/dashboard/src/i18n.ts
+++ b/packages/dashboard/src/i18n.ts
@@ -29,6 +29,52 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   ja: '日本語',
 };
 
+/**
+ * IANA timezone per locale — chosen as the "most representative" region,
+ * not a fixed offset, so DST is handled automatically by Intl.DateTimeFormat.
+ *
+ *   ko → Asia/Seoul     (UTC+9,  no DST)
+ *   ja → Asia/Tokyo     (UTC+9,  no DST)
+ *   zh → Asia/Shanghai  (UTC+8,  no DST)
+ *   en → America/New_York (UTC-5/-4, ET with DST)
+ *   es → Europe/Madrid  (UTC+1/+2, Madrid time with DST)
+ *
+ * If a user's physical location differs (e.g. en speaker in California),
+ * this is still a sensible default — individual overrides are a follow-up.
+ */
+export const TIMEZONE_BY_LOCALE: Record<Locale, string> = {
+  en: 'America/New_York',
+  ko: 'Asia/Seoul',
+  zh: 'Asia/Shanghai',
+  es: 'Europe/Madrid',
+  ja: 'Asia/Tokyo',
+};
+
+/**
+ * Render a stored UTC ISO timestamp as `YYYY-MM-DD HH:MM:SS` in the locale's
+ * home timezone. DB rows stay in UTC; UI does the conversion at render time
+ * so language switching doesn't require a DB rewrite.
+ */
+export function formatLocalDateTime(isoUtc: string, locale: Locale): string {
+  const d = new Date(isoUtc);
+  if (Number.isNaN(d.getTime())) return isoUtc;
+  const tz = TIMEZONE_BY_LOCALE[locale] ?? 'UTC';
+  // `en-CA` gives YYYY-MM-DD, HH:MM:SS — the only built-in locale that
+  // produces ISO-style ordering without rebuilding from parts.
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(d);
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? '';
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}:${get('second')}`;
+}
+
 export interface Dictionary {
   /* common / chrome */
   'nav.overview': string;

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -21,7 +21,7 @@ import {
   renderDeepAnalysisSection,
   tierBadge,
 } from './html.js';
-import { type Locale, resolveLocale, t } from './i18n.js';
+import { type Locale, formatLocalDateTime, resolveLocale, t } from './i18n.js';
 import { getRuleExampleKo } from './rule-examples.js';
 
 export interface DashboardDeps {
@@ -342,7 +342,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                 `<a href="/prompts/${r.id}?lang=${locale}" class="flex items-center gap-4 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
                    <span class="font-mono text-sm w-10 text-right">${r.score >= 0 ? r.score : '-'}</span>
                    ${tierBadge(r.tier, locale)}
-                   <span class="text-xs text-gray-400 w-36">${escapeHtml(r.created_at)}</span>
+                   <span class="text-xs text-gray-400 w-36 font-mono whitespace-nowrap">${escapeHtml(formatLocalDateTime(r.created_at, locale))}</span>
                    <span class="text-sm text-gray-700 dark:text-zinc-200 flex-1 truncate">${escapeHtml(r.snippet)}</span>
                  </a>`
             )
@@ -454,7 +454,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
             .map(
               (r) =>
                 `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}?lang=${locale}'">
-                   <td class="p-2 text-gray-500 text-xs font-mono whitespace-nowrap">${escapeHtml(r.created_at)}</td>
+                   <td class="p-2 text-gray-500 text-xs font-mono whitespace-nowrap">${escapeHtml(formatLocalDateTime(r.created_at, locale))}</td>
                    <td class="p-2 font-mono">${r.score >= 0 ? r.score : '-'}</td>
                    <td class="p-2">${tierBadge(r.tier, locale)}</td>
                    <td class="p-2 text-xs text-gray-600 dark:text-zinc-300">${escapeHtml(r.source)}</td>
@@ -638,7 +638,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
           <div>id: ${escapeHtml(u.id)}</div>
           <div>${escapeHtml(t(locale, 'detail.session'))}: <a class="underline hover:text-accent" href="/sessions/${u.session_id}?lang=${locale}">${escapeHtml(u.session_id)}</a></div>
           <div>${u.char_len} ${escapeHtml(t(locale, 'detail.chars'))} · ${u.word_count} ${escapeHtml(t(locale, 'detail.words'))} · ${escapeHtml(t(locale, 'detail.turn'))} ${u.turn_index} · <span class="uppercase">${escapeHtml(detected)}</span></div>
-          <div>${escapeHtml(u.created_at)}</div>
+          <div>${escapeHtml(formatLocalDateTime(u.created_at, locale))}</div>
         </div>
       </details>`;
     reply.type('text/html; charset=utf-8').send(

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -855,3 +855,73 @@ describe('dashboard favicon', () => {
     await app.close();
   });
 });
+
+// Locale-aware Created column (D-042) — DB stores UTC ISO; UI renders
+// YYYY-MM-DD HH:MM:SS in the locale's home timezone.
+describe('Prompts table · Created column timezone', () => {
+  // Pick a fixed UTC instant with NO DST ambiguity so the assertions stay
+  // stable year-round. 2026-06-15 03:30:45 UTC → mid-summer, DST-active
+  // windows are on the other side of noon so conversions are deterministic.
+  const FIXED_UTC = '2026-06-15T03:30:45.000Z';
+
+  async function setup(): Promise<{ id: string }> {
+    const db = openDb();
+    upsertSession(db, { id: 's-tz', cwd: '/tmp' });
+    const u = insertPromptUsage(db, {
+      session_id: 's-tz',
+      prompt_text: 'tz test',
+      created_at: FIXED_UTC,
+    });
+    db.close();
+    return { id: u.id };
+  }
+
+  it('KO renders Seoul time (UTC+9): 12:30:45 on the 15th', async () => {
+    await setup();
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
+    expect(res.body).toContain('2026-06-15 12:30:45');
+    await app.close();
+  });
+
+  it('JA renders Tokyo time (UTC+9) — same as Seoul', async () => {
+    await setup();
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=ja' });
+    expect(res.body).toContain('2026-06-15 12:30:45');
+    await app.close();
+  });
+
+  it('ZH renders Shanghai time (UTC+8): 11:30:45', async () => {
+    await setup();
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=zh' });
+    expect(res.body).toContain('2026-06-15 11:30:45');
+    await app.close();
+  });
+
+  it('ES renders Madrid summer time (CEST, UTC+2): 05:30:45', async () => {
+    await setup();
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=es' });
+    expect(res.body).toContain('2026-06-15 05:30:45');
+    await app.close();
+  });
+
+  it('EN renders New York summer time (EDT, UTC-4): 2026-06-14 23:30:45', async () => {
+    await setup();
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=en' });
+    expect(res.body).toContain('2026-06-14 23:30:45');
+    await app.close();
+  });
+
+  it('does NOT render the raw UTC ISO string (no T, no Z, no milliseconds)', async () => {
+    await setup();
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
+    // The raw literal `2026-06-15T03:30:45.000Z` must no longer appear.
+    expect(res.body).not.toContain('2026-06-15T03:30:45.000Z');
+    await app.close();
+  });
+});


### PR DESCRIPTION
## 요약 / Summary

대시보드의 `created_at` 을 **UTC ISO 원본** 에서 **로케일별 현지 시간 YYYY-MM-DD HH:MM:SS** 로 변경. DB 는 UTC 유지, UI 에서 `Intl.DateTimeFormat` + IANA 타임존 이름으로 렌더 시 변환. DST 가 있는 en·es 는 tzdata 로 자동 보정.

## Before / After

| 로케일 | Before (raw UTC) | After |
|---|---|---|
| `ko` | `2026-06-15T03:30:45.000Z` | `2026-06-15 12:30:45` (Seoul +9) |
| `ja` | `2026-06-15T03:30:45.000Z` | `2026-06-15 12:30:45` (Tokyo +9) |
| `zh` | `2026-06-15T03:30:45.000Z` | `2026-06-15 11:30:45` (Shanghai +8) |
| `es` | `2026-06-15T03:30:45.000Z` | `2026-06-15 05:30:45` (Madrid CEST +2, DST) |
| `en` | `2026-06-15T03:30:45.000Z` | `2026-06-14 23:30:45` (NY EDT -4, DST) |

## 설계 / Design

- **DB 는 UTC 유지** — 로케일 전환해도 row 재작성 불필요
- **UI 렌더 시점 변환** — `Intl.DateTimeFormat('en-CA', { timeZone, hour12: false, year/month/day/hour/minute/second: '2-digit' })`
- **IANA 타임존 이름** (`Asia/Seoul` 등) 사용 — fixed offset 대신 씀. DST 환절기(3월·11월) 에 en·es 자동 1시간 이동
- `en-CA` 포맷 로케일은 `YYYY-MM-DD` 순서를 내장 → 파트 재조립 비용 없음

## 적용 위치 / Surfaces

3곳 공통 헬퍼 (`formatLocalDateTime`) 로 일관:

| 파일 | 위치 |
|---|---|
| `server.ts` | Prompts 테이블 `Created` 셀 |
| `server.ts` | Overview "Recent" 리스트의 timestamp 스팬 |
| `server.ts` | Detail `<details>` meta 의 `created_at` 라인 |

## 테스트 / Tests

- [x] **232/232 pass** (6 신규 회귀 테스트)
  - KO 서울 `2026-06-15 12:30:45`
  - JA 도쿄 `2026-06-15 12:30:45` (UTC+9 동일)
  - ZH 상하이 `2026-06-15 11:30:45`
  - ES 마드리드 서머타임 `2026-06-15 05:30:45`
  - EN 뉴욕 서머타임 `2026-06-14 23:30:45` (날짜 경계 넘김)
  - raw `T...Z` 문자열 응답 내 0건 (회귀 방지)
- [x] 로컬 47824 실측 — KO/EN/ZH 응답에서 변환된 시간 확인, ISO suffix 0건

## Known limits

- **en 은 `America/New_York` 고정** — LA (PT)·Chicago (CT) 유저는 여전히 ET 로 표시. 개별 타임존 오버라이드 는 후속 과제
- **es 는 `Europe/Madrid` 고정** — Canary Islands (`Atlantic/Canary`) 는 1시간 오차. 소수 케이스

## D-042 결정 로그

`docs/00-decision-log.md` 에 D-042 추가 — 왜 fixed offset 대신 IANA 이름을 썼는지, 어떤 3 곳에 적용했는지, 알려진 한계 포함.

## 브랜치

`feat/locale-aware-created-at` → `main`. 다른 open PR 없음, 충돌 위험 0.