### PR TITLE
feat(dashboard): Prompts 목록 전 행에 힌트 (D-045 · supersedes D-043) / Show hint on every Prompts row

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -512,10 +512,14 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         <tbody>
           ${rows
             .map((r) => {
-              // Inline improvement hint — only for weak/bad tiers, KO locale.
-              // Other tiers stay single-line to keep the table dense.
-              const showHint = (r.tier === 'weak' || r.tier === 'bad') && locale === 'ko';
-              const shortTip = showHint && r.top_rule_id ? getRuleShortTipKo(r.top_rule_id) : null;
+              // Inline improvement hint — shown whenever the row has at
+              // least one rule hit, any tier. D-045 supersedes D-043's
+              // weak/bad-only restriction: good-tier rows with no hits
+              // stay single-line naturally (top_rule_id = null), while
+              // ok/weak/bad rows gain one line of "what to improve next
+              // time" so users can scan the whole list without drilling in.
+              const shortTip =
+                locale === 'ko' && r.top_rule_id ? getRuleShortTipKo(r.top_rule_id) : null;
               const hintLine = shortTip
                 ? `<div class="text-xs text-gray-500 dark:text-zinc-400 italic mt-0.5 truncate">→ ${escapeHtml(shortTip)}</div>`
                 : '';

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -905,19 +905,47 @@ describe('Prompts list · inline hint (weak/bad KO)', () => {
     await app.close();
   });
 
-  it('does NOT render hint for good-tier rows (signal preservation)', async () => {
+  // D-045 supersedes D-043's weak/bad-only restriction. Any row with a
+  // rule hit now shows its shortTip, regardless of tier — so users can
+  // scan the list and see "what to improve next time" for every
+  // imperfect prompt, not just the worst ones.
+  it('renders hint for good-tier rows that still have a rule hit', async () => {
     await seedPromptWithHit('good', 'R004');
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    expect(res.body).not.toContain('→ 한 번에 한 가지만');
+    expect(res.body).toContain('→ 한 번에 한 가지만');
     await app.close();
   });
 
-  it('does NOT render hint for ok-tier rows', async () => {
+  it('renders hint for ok-tier rows', async () => {
     await seedPromptWithHit('ok', 'R004');
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    expect(res.body).not.toContain('→ 한 번에 한 가지만');
+    expect(res.body).toContain('→ 한 번에 한 가지만');
+    await app.close();
+  });
+
+  it('does NOT render hint when a prompt has no rule hits', async () => {
+    const db = openDb();
+    upsertSession(db, { id: 's-clean', cwd: '/tmp' });
+    const u = insertPromptUsage(db, {
+      session_id: 's-clean',
+      prompt_text: 'clean prompt no hits',
+    });
+    upsertQualityScore(db, {
+      usage_id: u.id,
+      rule_score: 95,
+      final_score: 95,
+      tier: 'good',
+      rules_version: 1,
+    });
+    // Note: intentionally NO insertRuleHit — the prompt passed every rule.
+    db.close();
+
+    const app = buildDashboardServer({ rootOverride: tmp });
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
+    // Rows without any rule hit keep the snippet as a single line.
+    expect(res.body).not.toContain('→');
     await app.close();
   });
 


### PR DESCRIPTION
## 요약 / Summary

유저 피드백: Prompts 목록에서 **한 줄 개선 힌트가 보였다 사라짐**. 이유 추적 결과, D-043 이 `weak/bad tier 만` 으로 게이팅해 둔 게 원인. 유저 데이터에서 최근 프롬프트가 점점 개선되어 ok/good 으로 이동 (현재: 최근 100건 중 ok 77 · good 23 · weak/bad 0) → **가장 코칭이 필요한 순간에 힌트가 사라지는 역효과**.

유저 선호: "하나하나 체크하지 않아도 이해할 수 있는 구조" = **모든 행에 힌트 상시 표시**.

## 원인 진단

| 데이터 레이어 | 값 |
|---|---|
| DB 전체 tier 분포 | ok 2999 · good 652 · weak 142 · bad 2 |
| 최근 100건 (LIMIT 100) | **ok 77 · good 23** (weak/bad **0건**) |
| D-043 gate | `(tier === 'weak' || tier === 'bad') && locale === 'ko'` |
| 결과 | 최근 100건 모두 조건 불통과 → **힌트 100건 중 0건** |

코드는 정상, 게이팅 논리가 부작용.

## 변경

서버 측 한 조건 제거:

```ts
// Before
const showHint = (r.tier === 'weak' || r.tier === 'bad') && locale === 'ko';
const shortTip = showHint && r.top_rule_id ? getRuleShortTipKo(r.top_rule_id) : null;

// After  
const shortTip = locale === 'ko' && r.top_rule_id ? getRuleShortTipKo(r.top_rule_id) : null;
```

자연스러운 결과:
- **rule_hit 있는 ok/weak/bad 행** → 힌트 1 줄
- **rule_hit 있는 good 행** (드물지만 가능) → 힌트 표시 (개선 여지가 있다면 알려줌)
- **rule_hit 없는 good 행** → 1줄 유지 (top_rule_id = null → shortTip null → 힌트 미렌더)

## D-045 결정 (supersedes D-043)

**D-043 원칙** (tier-gating): "good/ok 는 합격이니 nag 안 함"  
**D-045 원칙** (hit-gating): "**rule_hit 가 있다 = 고칠 여지가 있다** 는 신호. 완벽(hit 0)이면 자연 clean"

유저 데이터가 이 대체를 실증:
- 최근 100건 ok/good = rule_hit 는 있음 (미세 개선 여지)
- tier 기반 차단 = 유저 코칭 단절
- hit 기반 표시 = 학습 루프 지속

## 테스트 / Tests

- [x] `pnpm -F @think-prompt/dashboard exec vitest run` — **67/67 pass** (66 → 67)
  - 의미 반전: `renders hint for good-tier rows that still have a rule hit` (KO)
  - 의미 반전: `renders hint for ok-tier rows`
  - 신규: `does NOT render hint when a prompt has no rule hits` (깨끗한 good 행 회귀)
  - 기존: 비-KO 로케일 스킵 유지
- [x] 로컬 47824 라이브 실측:
  - 힌트 렌더 **0 → 100** 건 (최근 100 행 모두 표시)
  - 다양한 룰: R001/R002/R003/R004/R006 shortTip 함께 노출

## Before / After (live data)

Before (PR #42 이전까지의 동작):
```
2026-04-24 13:48  72  OK    claude-code  "리팩토링해줘"
2026-04-24 13:50  55  WEAK  claude-code  "이 문서 요약 // 번역"
                                          → 한 번에 한 가지만 부탁하세요.
```

After (이 PR 머지 후):
```
2026-04-24 13:48  72  OK    claude-code  "리팩토링해줘"
                                          → 성공 기준 한 줄을 추가하세요.
2026-04-24 13:50  55  WEAK  claude-code  "이 문서 요약 // 번역"
                                          → 한 번에 한 가지만 부탁하세요.
```

## 브랜치

`feat/prompts-hint-all-tiers` → `main`. 단일 커밋 · 2 파일 · +40/-8.