### PR TITLE
fix(dashboard): D-042 로케일 타임존 렌더 재적용 / Re-apply D-042 locale timezone render

### DIFF
--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -1,4 +1,4 @@
-import { LOCALE_LABELS, type Locale, t } from './i18n.js';
+import { LOCALE_LABELS, type Locale, formatLocalDateTime, t } from './i18n.js';
 
 export function escapeHtml(s: unknown): string {
   return String(s ?? '')
@@ -461,7 +461,7 @@ function renderDeepAnalysisCard(a: DeepAnalysisViewRow, locale: Locale): string 
     return `
       <div class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-4">
         <div class="text-xs text-red-700 dark:text-red-300 mb-2">
-          ${escapeHtml(t(locale, 'analysis.failed'))} · ${escapeHtml(a.created_at)}
+          ${escapeHtml(t(locale, 'analysis.failed'))} · ${escapeHtml(formatLocalDateTime(a.created_at, locale))}
         </div>
         <div class="text-xs text-gray-700 dark:text-zinc-200">${escapeHtml(a.error_message ?? '')}</div>
       </div>`;
@@ -501,7 +501,7 @@ function renderDeepAnalysisCard(a: DeepAnalysisViewRow, locale: Locale): string 
     <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-4 border-l-4 border-l-accent">
       <div class="flex items-center justify-between mb-3">
         <div class="text-xs text-gray-500">
-          ${escapeHtml(a.model)} · ${escapeHtml(a.created_at)}
+          ${escapeHtml(a.model)} · ${escapeHtml(formatLocalDateTime(a.created_at, locale))}
         </div>
         ${tokens}
       </div>

--- a/packages/dashboard/src/i18n.ts
+++ b/packages/dashboard/src/i18n.ts
@@ -29,6 +29,42 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   ja: '日本語',
 };
 
+/**
+ * IANA timezone per locale — "most representative" region (not a fixed offset),
+ * so DST is handled automatically by Intl.DateTimeFormat. DB keeps UTC ISO;
+ * UI converts at render time (D-042).
+ */
+export const TIMEZONE_BY_LOCALE: Record<Locale, string> = {
+  en: 'America/New_York',
+  ko: 'Asia/Seoul',
+  zh: 'Asia/Shanghai',
+  es: 'Europe/Madrid',
+  ja: 'Asia/Tokyo',
+};
+
+/**
+ * Render a stored UTC ISO timestamp as `YYYY-MM-DD HH:MM:SS` in the locale's
+ * home timezone. `en-CA` is the only built-in locale that emits ISO-style
+ * ordering directly (D-042).
+ */
+export function formatLocalDateTime(isoUtc: string, locale: Locale): string {
+  const d = new Date(isoUtc);
+  if (Number.isNaN(d.getTime())) return isoUtc;
+  const tz = TIMEZONE_BY_LOCALE[locale] ?? 'UTC';
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(d);
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? '';
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}:${get('second')}`;
+}
+
 export interface Dictionary {
   /* common / chrome */
   'nav.overview': string;

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -21,7 +21,7 @@ import {
   renderDeepAnalysisSection,
   tierBadge,
 } from './html.js';
-import { type Locale, resolveLocale, t } from './i18n.js';
+import { type Locale, formatLocalDateTime, resolveLocale, t } from './i18n.js';
 import { getRuleExampleKo, getRuleShortTipKo } from './rule-examples.js';
 
 export interface DashboardDeps {
@@ -394,7 +394,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                 `<a href="/prompts/${r.id}?lang=${locale}" class="flex items-center gap-4 p-3 hover:bg-gray-50 dark:hover:bg-zinc-700">
                    <span class="font-mono text-sm w-10 text-right">${r.score >= 0 ? r.score : '-'}</span>
                    ${tierBadge(r.tier, locale)}
-                   <span class="text-xs text-gray-400 w-36">${escapeHtml(r.created_at)}</span>
+                   <span class="text-xs text-gray-400 w-36">${escapeHtml(formatLocalDateTime(r.created_at, locale))}</span>
                    <span class="text-sm text-gray-700 dark:text-zinc-200 flex-1 truncate">${escapeHtml(r.snippet)}</span>
                  </a>`
             )
@@ -524,7 +524,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                 ? `<div class="text-xs text-gray-500 dark:text-zinc-400 italic mt-0.5 truncate">→ ${escapeHtml(shortTip)}</div>`
                 : '';
               return `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}?lang=${locale}'">
-                   <td class="p-2 text-gray-500 text-xs font-mono whitespace-nowrap align-top">${escapeHtml(r.created_at)}</td>
+                   <td class="p-2 text-gray-500 text-xs font-mono whitespace-nowrap align-top">${escapeHtml(formatLocalDateTime(r.created_at, locale))}</td>
                    <td class="p-2 font-mono align-top">${r.score >= 0 ? r.score : '-'}</td>
                    <td class="p-2 align-top">${tierBadge(r.tier, locale)}</td>
                    <td class="p-2 text-xs text-gray-600 dark:text-zinc-300 align-top">${escapeHtml(r.source)}</td>
@@ -711,7 +711,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
           <div>id: ${escapeHtml(u.id)}</div>
           <div>${escapeHtml(t(locale, 'detail.session'))}: <a class="underline hover:text-accent" href="/sessions/${u.session_id}?lang=${locale}">${escapeHtml(u.session_id)}</a></div>
           <div>${u.char_len} ${escapeHtml(t(locale, 'detail.chars'))} · ${u.word_count} ${escapeHtml(t(locale, 'detail.words'))} · ${escapeHtml(t(locale, 'detail.turn'))} ${u.turn_index} · <span class="uppercase">${escapeHtml(detected)}</span></div>
-          <div>${escapeHtml(u.created_at)}</div>
+          <div>${escapeHtml(formatLocalDateTime(u.created_at, locale))}</div>
         </div>
       </details>`;
     reply.type('text/html; charset=utf-8').send(


### PR DESCRIPTION
## Summary / 요약

**v0.5.0 릴리스가 주장했지만 실제로는 누락됐던 D-042 로케일 타임존 렌더 로직을 main 위에 최소 패치로 재적용**합니다.

- v0.5.0 릴리스 커밋 `b6bad87` 의 CHANGELOG 는 D-042 (locale-aware created_at) 를 포함한다고 표기.
- 실제로는 PR #41 (`feat/locale-aware-created-at`) 이 머지되지 않은 채 릴리스 → 대시보드의 모든 `created_at` 이 여전히 UTC ISO (`…T…Z`) 로 노출.
- PR #41 을 rebase 하려면 15+ 개의 intervening PR (특히 rewrite 기능 제거, 룰 예제, hints 등 server.ts 대폭 변경) 과의 충돌 처리 필요.
- 비용 대비: 625bf7b 의 코어 변경 (i18n helper + 5 render sites) 을 current main 에 **minimal 재적용**이 더 깔끔.

## What changed / 변경

| 파일 | 변경 |
|---|---|
| `packages/dashboard/src/i18n.ts` | `TIMEZONE_BY_LOCALE` + `formatLocalDateTime(isoUtc, locale)` 추가 |
| `packages/dashboard/src/server.ts` | Recent · Prompts 리스트 · Detail meta 3곳 |
| `packages/dashboard/src/html.ts` | Deep analysis 실패/성공 카드 2곳 |

Locale → IANA timezone: `ko→Asia/Seoul, ja→Asia/Tokyo, zh→Asia/Shanghai, en→America/New_York (DST), es→Europe/Madrid (DST)`. DB 는 UTC 유지, 렌더 시점 변환 → 언어 전환 시 DB rewrite 불필요.

## Test plan / 테스트

- [x] `pnpm -F @think-prompt/dashboard typecheck` clean
- [x] `pnpm -F @think-prompt/dashboard test` — **67/67 pass**
- [ ] 머지 후 `pnpm -r build` + 대시보드 재시작해서 UI 육안 확인 (ko → `YYYY-MM-DD HH:MM:SS` Seoul time, en → New York time)

## Follow-up / 후속

- PR #41 은 이 PR 머지 후 close (stale branch). `feat/locale-aware-created-at` 브랜치 정리.
- CHANGELOG v0.5.0 섹션은 이미 D-042 를 포함한다고 기재되어 있으므로 이 PR 은 CHANGELOG 수정 없이 코드만 정합시킴 (릴리스 클레임 ↔ 실제 코드).

Refs: D-042, supersedes abandoned PR #41