### PR TITLE
feat(core,dashboard)!: 품질 스코어 4-tuple 계약 — 비대칭 + efficiency + baseline + confidence (D-046 · supersedes D-006) / Asymmetric score with efficiency, baseline, confidence

### DIFF
--- a/docs/00-decision-log.md
+++ b/docs/00-decision-log.md
@@ -453,7 +453,86 @@
 
 ---
 
+## D-046 · 품질 스코어 = {점수·이유·확신도·개인 delta} 4-tuple 계약 (D-006 supersede)
+
+- **Date:** 2026-04-24
+- **Problem:** D-006 은 "룰 70% + 실사용 30% + (의심 시) LLM judge" 선형 가중합을 고정했다. 실제 유저 체감은 세 방향에서 어긋나 있다.
+  1. **대칭 선형의 한계.** 현재 `rule_score = 100 - Σ(severity_weight)` 는 감점 전용·대칭. 유저가 "좋은 프롬프트는 후하게, 문제 있는 프롬프트는 팍팍" 을 원해도 공식상 불가능.
+  2. **시간/효율 축 부재.** 꼼꼼한 긴 프롬프트가 늘 더 좋은 것은 아니다. 짧아도 한 방에 의도가 해결되면 의미 있는 프롬프트인데, 현재 `usage_score` 에는 그 신호가 반영되지 않는다(실패율·재사용·길이·피드백만).
+  3. **환경 변수(뉘앙스·맥락·기분·대화 이력) 처리 부재.** 동일 문장이 서로 다른 맥락에서 서로 다른 가치를 가지는데 시스템이 이를 인정하지 않고 절대 점수만 단언 → 유저가 점수에 동의하지 못하면 신뢰가 무너진다.
+- **Decision (채택 Paradigm D — Hybrid + Confidence Signaling):** 품질 평가는 단일 숫자가 아니라 **4-tuple 계약**으로 제공된다. UI·API·저장 계층 전부 이 계약을 따른다.
+
+  ```
+  { score:number, top_issue:string, confidence:'high'|'medium'|'low', delta?:number }
+  ```
+
+  공식 변경은 네 개 축으로 정의된다:
+
+  1. **비대칭 cap floor (severity ceiling).** severity 4+ 히트가 하나라도 걸리면 최종 점수에 상한선 강제.
+     - severity ≥ 5 hit → `final_score ≤ 40` (bad 고정)
+     - severity ≥ 4 hit → `final_score ≤ 60` (weak 이하)
+     - severity 3 hit ≥ 2 개 → `final_score ≤ 75`
+     → 다른 항목이 100 이어도 가리지 못함. "팍팍 떨어뜨리기" 를 구조적으로 보장.
+
+  2. **Positive signal bonus.** 감점 전용에서 탈피. 출력 포맷·성공 기준·예시·파일 경로 등 "있으면 좋은 것" 이 있을 때 **최대 +10 까지 bonus**. 감점 없고 양성 신호 있으면 100 쉽게 도달.
+
+  3. **Efficiency 축 (usage_score 의 새 지표).** Tier 2 worker 가 transcript JSONL 을 이미 파싱하므로 다음 신호를 추출해 가중 평균에 투입:
+     - **first-shot success**: 후속 프롬프트가 correction 패턴("다시/아니/취소/수정") 이 아니면 100, 있으면 감점
+     - **tool call 경제성**: 의도 대비 tool_use 수 (적을수록 좋음)
+     - **turn duration**: Stop 훅까지 경과 시간
+     `usage_score` 가중치 재편: `efficiency 0.20 + fail 0.25 + reuse 0.20 + length 0.10 + feedback 0.25` (efficiency 신규, length/fail/reuse 비중 축소).
+
+  4. **Confidence signaling.** 모든 점수에 high/medium/low 확신도 부여. 계산 근거:
+     - **high**: severity 3+ 히트 명확 AND (usage_score 존재 OR judge_score 존재), baseline 과 일치
+     - **medium**: 기본값
+     - **low**: 룰 히트는 있으나 severity 2 이하만, 또는 맥락 피처가 특이(첫 턴·매우 긴 세션 말미·correction 직후), 또는 baseline 대비 delta ±25 초과
+     → UI 는 low confidence 점수 뒤에 "참고용" 레이블을 노출해 유저가 점수에 대들 근거 제공. 시스템이 자기 한계를 인정하는 **신뢰 계약**.
+
+  5. **개인 baseline delta (Phase 3, 점진 활성화).** 유저 누적 턴 ≥ 50 이 되면 `user_baseline_snapshot` 에 rolling window 30일 기준 {avg_rule_score, avg_word_count, avg_severity_count} 저장. 점수 표시는 이중:
+     - 절대: `72 / ok (확신 높음)`
+     - delta: `당신 평균 78 대비 -6`
+     50턴 미만에서는 `calibrating...` 라벨로 정직하게 표시.
+
+- **Rationale:**
+  - **환경 변수를 "전부 반영" 도 "전부 무시" 도 실패다.** 전부 반영(LLM judge 의존) → 비용·프라이버시·불투명. 전부 무시(현재) → 기계적·불공정. 중간 길은 **"반영할 것은 피처로 쓰고 시스템이 자기 확신도를 노출"**.
+  - **moat 분석.** 룰셋(A)·LLM judge(B)·개인 캘리브레이션(C) 각각은 경쟁자가 복제 가능. 그러나 **로컬 longitudinal 데이터 + confidence signaling + 개인 baseline** 의 결합은 D-004(로컬 중심) 덕분에 복제 난이도 상승. 성공 확률 추정 A 40% / B 30% / C 50% / D 70%.
+  - **콜드스타트 2 주는 피할 수 없다.** 초기 50턴 이전엔 Phase 3/4 효과 없음 → `calibrating...` UX 로 정직하게 표시. 유저가 "아직 데이터 모으는 중" 을 이해하면 신뢰 손실 없음.
+  - **D-032(미션) 와의 정합.** "점수가 진짜 낮아야 유저가 자각한다" 는 cap floor 로, "잘 쓴 프롬프트에 자신감" 은 positive bonus 로, "프롬프트 자각" 은 confidence + delta 의 투명성으로 강화됨.
+
+- **Alternatives considered:**
+  - ① 현재 공식 미세 튜닝(severity 가중치만 재조정) — 대칭 선형의 한계를 해결 못 함. 반려.
+  - ② LLM judge 를 기본값으로 (primary scorer) — 비용·프라이버시·불투명. 반려.
+  - ③ 개인 캘리브레이션 단독 — 콜드스타트 기간 사용 불가. D 의 일부로 흡수.
+
+- **Scope / 영향:**
+  - **공식 재작성:** `docs/05-quality-engine.md` §3~§7 전면 재작성 (응당 이 D-046 과 함께 본 PR 에 포함).
+  - **schema:** `MIGRATION_006` — `prompt_usages` 에 `efficiency_score INT`, `confidence TEXT`, `baseline_delta INT` 추가. `user_baseline_snapshots(scope,window_days,computed_at,avg_final_score,avg_word_count,sample_size,snapshot_json)` 테이블 신규.
+  - **scorer.ts:** `applyCap()`, `computeEfficiencyScore()`, `computeConfidence()`, `composeFinalScore()` 확장. Tier 밴드 **90/70/50 상향** (현재 85/65/45 → 새 밴드).
+  - **신규 모듈:** `packages/core/src/baseline.ts` (rolling avg), `packages/core/src/confidence.ts`.
+  - **rules:** R001·R010·R011 severity **2 → 1** (구조/스타일 완화). R004·R012 severity **3 → 4** (다중 태스크·코드 덤프 강화). R005 유지(5).
+  - **worker:** `handleParseTranscript` 가 efficiency 피처 추출 후 `computeEfficiencyScore` 호출 → `prompt_usages.efficiency_score` 갱신 → `composeFinalScore` 재실행.
+  - **dashboard:** 디테일 페이지 hero 에 `confidence` 배지 + baseline delta 한 줄. Prompts 리스트 `tier` 셀 옆 confidence 보조 글자. 데이터 < 50 이면 상단 `calibrating…` 안내.
+  - **config:** `scorer.baseline_min_samples: 50`, `scorer.baseline_window_days: 30`, `scorer.confidence.low_delta_threshold: 25` 추가.
+
+- **Known limits / 후속:**
+  - first-shot success 추정은 휴리스틱. 유저 만족 vs 포기 구분 오탐 가능 → 초기 가중치 보수적(0.20). 1 개월 데이터로 튜닝.
+  - baseline delta 는 첫 50턴 이전 비활성. 쿠킹 기간 동안 confidence 기본 `medium`.
+  - LLM judge 트리거 조건 변경: `rule_score < 60` → `confidence == 'low'`. 비용 자연스럽게 관리됨.
+
+- **관계:**
+  - **D-006(룰 70% + 실사용 30%):** **supersede** — 아래 취소 섹션에 이전.
+  - **D-032(미션):** "인지 고착 해소 + 프롬프트 자각" 을 cap floor + confidence + delta 로 구체화.
+  - **D-004(로컬 중심):** baseline · confidence · delta 모두 로컬에서 계산. LLM judge 호출 빈도 오히려 감소.
+
+### D-006 상태: 취소 (superseded by D-046)
+
+---
+
 ## 취소된 결정
+
+### D-006 · 품질 스코어 구성 (룰 70% + 실사용 30%, LLM 심판 `rule_score < 60`)
+- **취소 이유:** 선형 대칭 가중합은 "좋은 건 더 좋게, 나쁜 건 팍팍" 을 구조적으로 표현할 수 없고, usage_score 에 시간/효율 축이 비어 있어 "짧아도 한 방에 풀린 프롬프트" 를 인정할 수 없다. 환경 변수(뉘앙스·맥락·기분) 에 대한 시스템의 자기 확신도 노출 장치도 없음. D-046 으로 대체.
+- **취소일:** 2026-04-24
 
 ### D-026 · 자동 리라이트 전략 (단일 버전 메타 프롬프트 · accept/reject)
 - **취소 이유:** 유저의 명시적 피드백 — 자동 리라이트가 원래 제품 방향이 아니며, 유저 자각을 약화시키는 방향. `think-prompt rewrite` CLI, `rewrites` 테이블, 대시보드 UI 전부 제거. D-041 로 대체.

--- a/docs/05-quality-engine.md
+++ b/docs/05-quality-engine.md
@@ -1,7 +1,7 @@
 # 05 · 품질 엔진 (룰셋 · 스코어 · LLM 심판 · 리라이터)
 
 > 이 문서 하나로 품질 평가 로직 전부 구현 가능하도록.
-> D-006: 룰 70% + 실사용 30%. LLM 심판은 `final_score < 60` 케이스에만 trigger.
+> **D-046** (D-006 supersede): 품질 평가는 단일 숫자가 아니라 `{score, top_issue, confidence, delta}` **4-tuple 계약**. 비대칭 cap floor · positive bonus · efficiency 축 · 개인 baseline delta · confidence signaling 의 다섯 축으로 구성.
 
 ---
 
@@ -97,56 +97,130 @@ const FORMAT_KEYWORDS = [
 
 ---
 
-## 3. 품질 스코어 공식
+## 3. 품질 스코어 공식 (D-046)
 
-### 3.1 정의
-```
-final_score = round(
-  0.7 * rule_score
-  + 0.3 * usage_score
-)
-```
-- **`rule_score`**: 룰베이스 결정론 (필수)
-- **`usage_score`**: 실사용 메트릭 (없으면 스킵하고 rule_score만)
+### 3.1 정의 — 4-tuple 계약
 
-### 3.2 `rule_score` 계산
-```
-rule_score = max(0, 100 - Σ(severity_weight))
-```
-severity_weight:
-| severity | weight |
-|---|---|
-| 1 | 2 |
-| 2 | 5 |
-| 3 | 10 |
-| 4 | 18 |
-| 5 | 30 |
+점수는 항상 네 개 값을 묶어서 제공된다:
 
-### 3.3 `usage_score` 계산
-다음 지표의 가중 평균(세션 종료 후 계산). 데이터 없으면 NULL.
+```ts
+interface ScoreOutcome {
+  score:      number;                         // 0..100
+  tier:       'good' | 'ok' | 'weak' | 'bad';
+  confidence: 'high' | 'medium' | 'low';
+  delta?:     number;                         // baseline 대비 ± (데이터 쌓인 뒤)
+  top_issue?: string;                         // 한 줄 진단
+}
+```
+
+최종 점수는 아래 순서로 계산된다:
+
+```
+raw_score   = compose(rule_score, usage_score, judge_score)     (§3.4)
+bonus       = positiveBonus(signals)                            (§3.3, 최대 +10)
+capped      = applyCap(raw_score + bonus, severity_max_hit)     (§3.5)
+final_score = round(capped)
+delta       = final_score - user_baseline_snapshot.avg          (Phase 3, §5)
+confidence  = computeConfidence(hits, usage, judge, context)    (§6)
+```
+
+### 3.2 `rule_score` 계산 (감점 축)
+
+```
+rule_score_raw = max(0, 100 - Σ(severity_weight))
+```
+
+**severity_weight (D-046 반영, 룰 재조정 이후):**
+| severity | weight | 해당 룰 |
+|---|---|---|
+| 1 | 2 | R001·R008·R010·R011·R013(경미)·R018 |
+| 2 | 5 | R006·R007·R009·R013(중간)·R014·R015·R016·R017 |
+| 3 | 10 | R002·R003·R013(심각) |
+| 4 | 18 | R004·R012 |
+| 5 | 30 | R005 |
+
+### 3.3 Positive signal bonus (가점 축, D-046 신규)
+
+"있으면 좋은 것" 이 있을 때 `rule_score` 위에 최대 **+10 까지** 합산. 감점과 독립적으로 계산되며, 한 번 더해지면 `min(100, rule_score + bonus)` 로 cap.
+
+| signal | +점수 | 판정 |
+|---|---|---|
+| 출력 포맷 명시 | +3 | `FORMAT_KEYWORDS` 매칭 |
+| 성공 기준 제시 | +3 | `SUCCESS_CRITERIA_KEYWORDS` 매칭 |
+| 예시 포함 | +2 | `EXAMPLE_KEYWORDS` 매칭 (단, wordCount ≥ 40일 때) |
+| 파일 경로 / 버전 명시 | +2 | `FILE_PATH_PATTERNS` 또는 `VERSION_PATTERNS` 매칭 |
+
+합 `≤ 10`. 감점 0 + bonus 10 이면 `rule_score` 가 `100` 에 쉽게 도달.
+
+### 3.4 `usage_score` 계산 (D-046 efficiency 축 추가)
+
+```
+usage_score = 0.25*failScore + 0.20*reuseScore + 0.10*lengthScore
+            + 0.25*feedbackScore + 0.20*efficiencyScore
+```
+
 | 지표 | 계산 | 가중치 |
 |---|---|---|
-| 도구 실패율 | `1 - fail/calls` | 0.35 |
-| 재시도 비율 역수 | 같은 유사 프롬프트 반복 수 → 낮을수록 좋음 | 0.25 |
-| 응답 길이 적합성 | 요청 범위 대비 출력 길이 편차 | 0.15 |
-| 유저 피드백 | 👍/👎 명시(M6 이후) | 0.25 |
+| 도구 실패율 | `(1 - fail/calls) * 100` | **0.25** (기존 0.35) |
+| 재시도 비율 역수 | `(1 - min(1, reuse/5)) * 100` | **0.20** (기존 0.25) |
+| 응답 길이 적합성 | 범위 내 100 / 밖에서 편차 감점 | **0.10** (기존 0.15) |
+| 유저 피드백 | `ups/(ups+downs) * 100` | 0.25 (유지) |
+| **Efficiency (신규)** | §3.4.1 | **0.20** |
 
-MVP에선 상위 3개만 쓰고 피드백은 M6에서 추가.
+피드백/efficiency 모두 없으면 해당 항 가중치 제외하고 재정규화.
 
-### 3.4 Tier 매핑
-| final_score | tier | 대시보드 색 |
-|---|---|---|
-| 85–100 | good | 초록 |
-| 65–84 | ok | 노랑 |
-| 45–64 | weak | 주황 |
-| 0–44 | bad | 빨강 |
+#### 3.4.1 Efficiency 계산
+Tier 2 worker 가 transcript JSONL 파싱 시 추출:
+- **first_shot_success** (0 또는 1): 다음 턴의 프롬프트가 correction 패턴 (`/다시|아니|취소|재시도|redo|no wait/i`) 이면 0, 아니면 1. 마지막 턴은 1.
+- **tool_call_count**: 이 턴 동안 발생한 `tool_use` 이벤트 수.
+- **follow_up_depth**: 같은 의도의 연속 턴 수 (1 이 이상적).
+
+```
+efficiencyScore = clamp(0, 100,
+    firstShotSuccess * 60
+  + toolEconomyScore(tool_call_count) * 30
+  + followUpScore(follow_up_depth) * 10
+)
+```
+- `toolEconomyScore`: 0 calls → 100, 1~3 → 90, 4~8 → 75, 9~15 → 50, >15 → 25
+- `followUpScore`: 1 → 100, 2 → 70, 3 → 40, ≥4 → 20
+
+### 3.5 비대칭 cap floor (D-046 핵심)
+
+심각 룰 히트 시 상한선 강제. 다른 항목이 100 이어도 덮지 못함.
+
+```
+max_severity = max(severity in rule_hits, 0)
+severity3_count = count(hits where severity == 3)
+
+if max_severity >= 5:  cap = 40   // bad
+elif max_severity >= 4: cap = 60  // weak 이하
+elif severity3_count >= 2: cap = 75
+else: cap = 100
+
+final_score = min(raw_score + bonus, cap)
+```
+
+**왜 cap 인가:** severity weight 단순 감점으로는 severity 5 하나 + 다른 모든 요소 완벽 시 `30 점만 감점 → 70` 이 나와 "문제 있는 프롬프트" 가 `ok` tier 로 노출되는 모순. cap 은 이를 구조적으로 차단.
+
+### 3.6 Tier 매핑 (D-046 밴드 상향)
+
+| final_score | tier | 대시보드 색 | 의미 |
+|---|---|---|---|
+| 90–100 | good | 초록 | 감점 없음 + positive bonus. 자신감. |
+| 70–89 | ok | 노랑 | 경미한 개선 여지. |
+| 50–69 | weak | 주황 | 구조적 문제 또는 severity 3 히트. |
+| 0–49 | bad | 빨강 | severity 4+ 히트 또는 누적 감점 과다. |
+
+(기존: 85/65/45. good 진입 조건 강화 → positive bonus 없이는 진입 불가.)
 
 ---
 
 ## 4. LLM 심판 (Meta-Judge)
 
-### 4.1 Trigger
-- 기본값: `rule_score < 60` OR `final_score < 60` (usage 있을 때) OR R005(인젝션) 의심.
+### 4.1 Trigger (D-046 변경)
+- 기본값: **`confidence == 'low'`** (§6 참조) OR R005(인젝션) 의심. (기존 `rule_score < 60` 대체.)
+- low confidence 케이스만 잡으면 대부분의 명확한 점수는 judge 안 부르고 지나감 → 비용 자연 감소.
 - 한 프롬프트 해시당 **1회만** 호출(캐시). 룰 버전 바뀌면 재호출.
 - `llm.enabled=false`면 전부 건너뜀.
 
@@ -252,3 +326,62 @@ Return STRICT JSON:
 - 룰셋 전체 해시 = `rules_version`.
 - 스코어 행은 `rules_version` 포함 저장.
 - 룰셋 업데이트 릴리스 시 `think-prompt reprocess --all` CLI로 재채점 가능.
+
+---
+
+## 5. 개인 Baseline (D-046 Phase 3)
+
+### 5.1 계산 윈도우
+- **누적 턴 ≥ 50** 인 유저부터 활성화. 미만은 `delta = null` + UI `calibrating…` 라벨.
+- Rolling window: **최근 30일** 의 `quality_scores` 행.
+- 저장: `user_baseline_snapshots(scope, window_days, computed_at, avg_final_score, avg_word_count, sample_size, snapshot_json)`. 하루 1회 갱신 (worker 배치).
+
+### 5.2 Delta 계산
+```
+delta = final_score - snapshot.avg_final_score
+```
+- 유저 디테일 페이지: 절대 점수 옆에 `(당신 평균 78 대비 -6)` 형태.
+- 리스트: tier 배지 아래 `Δ-6` 같은 micro 표시.
+
+### 5.3 왜 개인 baseline 인가
+- 환경 변수(뉘앙스·맥락·기분·대화 이력) 는 **유저 자신의 평균과 비교** 할 때 자연스럽게 정규화됨.
+- "그날따라 짧게 쓴 프롬프트" 가 평균 대비 낮으면 유저도 납득. 다른 유저 평균과는 비교 안 함(D-004 로컬 원칙).
+
+---
+
+## 6. Confidence Signaling (D-046 Phase 4)
+
+### 6.1 판정
+```ts
+function computeConfidence(input): 'high' | 'medium' | 'low' {
+  const { max_severity, has_usage, has_judge, context_unusual, baseline_delta } = input;
+
+  // Low: 시스템이 자기 한계를 인정해야 하는 경우
+  if (context_unusual) return 'low';                  // 첫 턴, correction 직후, 매우 긴 세션 말미 등
+  if (baseline_delta != null && Math.abs(baseline_delta) > 25) return 'low';
+  if (max_severity <= 1 && !has_usage && !has_judge) return 'low'; // 신호 부족
+
+  // High: 명확한 판정
+  if (max_severity >= 3 && (has_usage || has_judge)) return 'high';
+  if (max_severity === 0 && has_usage) return 'high';
+
+  return 'medium';
+}
+```
+
+### 6.2 UI 표현
+- `high`: 점수 옆 작은 "●" (채워진 도트)
+- `medium`: "○" (빈 도트)
+- `low`: "○ 참고용" (한 줄 설명)
+
+### 6.3 왜 확신도를 노출하는가
+- **신뢰 계약.** 시스템이 자기 한계를 인정하면 유저가 점수에 대들지 않는다. 오히려 high-confidence 점수는 유저도 수용.
+- **LLM judge 트리거가 여기로 수렴.** `confidence == 'low'` 만 judge 를 호출 → 비용·프라이버시 자연 통제.
+
+---
+
+## 8. 콜드스타트 정책
+
+- **턴 수 < 50**: confidence 는 기본 `medium`, delta 비활성, UI 상단 `calibrating… (N/50)` 배너.
+- **턴 수 < 10**: Tier 밴드만 표시, 퍼센트 점수 숨김. "아직 당신 패턴을 배우는 중입니다" 문구.
+- 이 상태는 D-004(로컬 중심) · D-028(fail-open) 과 정합 — 데이터가 부족하면 과도한 단언을 하지 않는다.

--- a/packages/core/src/baseline.ts
+++ b/packages/core/src/baseline.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-user rolling baseline (D-046 §5).
+ *
+ * Phase 3 of D-046. The snapshot is stored in `user_baseline_snapshots`
+ * (MIGRATION_006). Activation threshold is 50 turns in the window — below
+ * that we return null and the dashboard renders a "calibrating…" banner.
+ *
+ * Thin wrappers around db.ts helpers + a pure `computeDelta` for testing.
+ */
+import type { Database as Db } from 'better-sqlite3';
+import { type BaselineSnapshotRow, getLatestBaseline, recomputeBaseline } from './db.js';
+
+export const BASELINE_DEFAULT_WINDOW_DAYS = 30;
+export const BASELINE_DEFAULT_MIN_SAMPLES = 50;
+
+export interface BaselineOpts {
+  scope?: string;
+  windowDays?: number;
+  minSamples?: number;
+}
+
+export function refreshBaseline(db: Db, opts: BaselineOpts = {}): BaselineSnapshotRow | null {
+  return recomputeBaseline(db, {
+    scope: opts.scope ?? 'global',
+    windowDays: opts.windowDays ?? BASELINE_DEFAULT_WINDOW_DAYS,
+    minSamples: opts.minSamples ?? BASELINE_DEFAULT_MIN_SAMPLES,
+  });
+}
+
+export function loadBaseline(db: Db, scope = 'global'): BaselineSnapshotRow | null {
+  return getLatestBaseline(db, scope);
+}
+
+/**
+ * Pure delta computation. Returns null when baseline is absent — callers
+ * MUST treat null as "cold start, do not display delta".
+ */
+export function computeDelta(
+  finalScore: number,
+  baseline: BaselineSnapshotRow | null
+): number | null {
+  if (!baseline) return null;
+  if (baseline.sample_size < BASELINE_DEFAULT_MIN_SAMPLES) return null;
+  return Math.round(finalScore - baseline.avg_final_score);
+}
+
+/**
+ * Convenience: returns both whether cold-start is still active and the
+ * sample-size progress, so the UI can show "N / 50" during warm-up.
+ */
+export function coldStartState(
+  baseline: BaselineSnapshotRow | null,
+  currentSampleSize: number,
+  minSamples = BASELINE_DEFAULT_MIN_SAMPLES
+): { coldStart: boolean; have: number; need: number } {
+  const have = baseline?.sample_size ?? currentSampleSize;
+  return { coldStart: have < minSamples, have, need: minSamples };
+}

--- a/packages/core/src/confidence.ts
+++ b/packages/core/src/confidence.ts
@@ -1,0 +1,43 @@
+/**
+ * Confidence signaling (D-046 §6).
+ *
+ * The system exposes its own uncertainty so users calibrate trust correctly:
+ *   high   — clear rule hits + usage/judge + baseline-consistent
+ *   medium — default when signals are mixed
+ *   low    — unusual context, extreme baseline drift, or weak signals only
+ *
+ * LLM judge trigger is rebound to `confidence === 'low'` (see worker/jobs.ts).
+ */
+
+export type Confidence = 'high' | 'medium' | 'low';
+
+export const LOW_CONFIDENCE_DELTA = 25;
+
+export interface ConfidenceInput {
+  maxSeverity: number; // 0..5, max across rule_hits
+  hasUsageScore: boolean;
+  hasJudgeScore: boolean;
+  /** Cold-start or unusual context — first turn, correction pattern right before, very long session tail. */
+  contextUnusual?: boolean;
+  /** Baseline delta (final_score - baseline.avg). null when cold-start. */
+  baselineDelta?: number | null;
+}
+
+export function computeConfidence(input: ConfidenceInput): Confidence {
+  if (input.contextUnusual) return 'low';
+  if (input.baselineDelta != null && Math.abs(input.baselineDelta) > LOW_CONFIDENCE_DELTA) {
+    return 'low';
+  }
+  if (input.maxSeverity <= 1 && !input.hasUsageScore && !input.hasJudgeScore) {
+    return 'low';
+  }
+
+  if (input.maxSeverity >= 3 && (input.hasUsageScore || input.hasJudgeScore)) {
+    return 'high';
+  }
+  if (input.maxSeverity === 0 && input.hasUsageScore) {
+    return 'high';
+  }
+
+  return 'medium';
+}

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -8,12 +8,13 @@ import {
   MIGRATION_003,
   MIGRATION_004,
   MIGRATION_005,
+  MIGRATION_006,
 } from './migrations/sql.js';
 import { getPaths } from './paths.js';
 import { maskPii } from './pii.js';
 import { ulid } from './ulid.js';
 
-const CURRENT_SCHEMA_VERSION = 5;
+const CURRENT_SCHEMA_VERSION = 6;
 
 export function openDb(rootOverride?: string): Db {
   const paths = getPaths(rootOverride);
@@ -42,6 +43,7 @@ function runMigrations(db: Db): void {
     { v: 3, sql: MIGRATION_003 },
     { v: 4, sql: MIGRATION_004 },
     { v: 5, sql: MIGRATION_005 },
+    { v: 6, sql: MIGRATION_006 },
   ];
   for (const m of migrations) {
     if (m.v <= current) continue;
@@ -230,12 +232,22 @@ export interface QualityScoreInput {
   final_score: number;
   tier: 'good' | 'ok' | 'weak' | 'bad';
   rules_version: number;
+  /** D-046: extra columns — nullable so legacy callers don't have to know about them yet. */
+  efficiency_score?: number | null;
+  bonus_score?: number | null;
+  cap_applied?: number | null;
+  confidence?: 'high' | 'medium' | 'low' | null;
+  baseline_delta?: number | null;
 }
 
 export function upsertQualityScore(db: Db, s: QualityScoreInput): void {
   db.prepare(
-    `INSERT INTO quality_scores(usage_id, rule_score, usage_score, judge_score, final_score, tier, computed_at, rules_version)
-     VALUES (@usage_id,@rule_score,@usage_score,@judge_score,@final_score,@tier,@computed_at,@rules_version)
+    `INSERT INTO quality_scores(usage_id, rule_score, usage_score, judge_score, final_score, tier,
+                                computed_at, rules_version,
+                                efficiency_score, bonus_score, cap_applied, confidence, baseline_delta)
+     VALUES (@usage_id,@rule_score,@usage_score,@judge_score,@final_score,@tier,
+             @computed_at,@rules_version,
+             @efficiency_score,@bonus_score,@cap_applied,@confidence,@baseline_delta)
      ON CONFLICT(usage_id) DO UPDATE SET
        rule_score=excluded.rule_score,
        usage_score=COALESCE(excluded.usage_score, quality_scores.usage_score),
@@ -243,13 +255,120 @@ export function upsertQualityScore(db: Db, s: QualityScoreInput): void {
        final_score=excluded.final_score,
        tier=excluded.tier,
        computed_at=excluded.computed_at,
-       rules_version=excluded.rules_version`
+       rules_version=excluded.rules_version,
+       efficiency_score=COALESCE(excluded.efficiency_score, quality_scores.efficiency_score),
+       bonus_score=COALESCE(excluded.bonus_score, quality_scores.bonus_score),
+       cap_applied=COALESCE(excluded.cap_applied, quality_scores.cap_applied),
+       confidence=COALESCE(excluded.confidence, quality_scores.confidence),
+       baseline_delta=COALESCE(excluded.baseline_delta, quality_scores.baseline_delta)`
   ).run({
     ...s,
     usage_score: s.usage_score ?? null,
     judge_score: s.judge_score ?? null,
+    efficiency_score: s.efficiency_score ?? null,
+    bonus_score: s.bonus_score ?? null,
+    cap_applied: s.cap_applied ?? null,
+    confidence: s.confidence ?? null,
+    baseline_delta: s.baseline_delta ?? null,
     computed_at: new Date().toISOString(),
   });
+}
+
+/**
+ * Persist per-turn efficiency features extracted by the worker from the
+ * transcript. Columns added by MIGRATION_006 (all nullable).
+ */
+export function updateUsageEfficiencyFeatures(
+  db: Db,
+  usage_id: string,
+  f: {
+    first_shot_success?: number | null;
+    tool_call_count?: number | null;
+    follow_up_depth?: number | null;
+  }
+): void {
+  db.prepare(
+    `UPDATE prompt_usages SET
+       first_shot_success = COALESCE(?, first_shot_success),
+       tool_call_count    = COALESCE(?, tool_call_count),
+       follow_up_depth    = COALESCE(?, follow_up_depth)
+     WHERE id = ?`
+  ).run(
+    f.first_shot_success ?? null,
+    f.tool_call_count ?? null,
+    f.follow_up_depth ?? null,
+    usage_id
+  );
+}
+
+export interface BaselineSnapshotRow {
+  id: string;
+  scope: string;
+  window_days: number;
+  computed_at: string;
+  sample_size: number;
+  avg_final_score: number;
+  avg_word_count: number;
+  avg_severity_hits: number;
+}
+
+/** Compute and persist the rolling-window baseline. Returns the row if sample was large enough,
+ *  null if below the minimum sample threshold (cold-start). */
+export function recomputeBaseline(
+  db: Db,
+  opts: { scope?: string; windowDays?: number; minSamples?: number } = {}
+): BaselineSnapshotRow | null {
+  const scope = opts.scope ?? 'global';
+  const windowDays = opts.windowDays ?? 30;
+  const minSamples = opts.minSamples ?? 50;
+
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS n,
+              AVG(q.final_score) AS avg_final,
+              AVG(u.word_count) AS avg_words,
+              AVG((SELECT COUNT(*) FROM rule_hits h WHERE h.usage_id = u.id AND h.severity >= 3)) AS avg_sev
+         FROM quality_scores q
+         JOIN prompt_usages u ON u.id = q.usage_id
+        WHERE u.created_at >= datetime('now', ?)`
+    )
+    .get(`-${windowDays} days`) as {
+    n: number;
+    avg_final: number | null;
+    avg_words: number | null;
+    avg_sev: number | null;
+  };
+
+  if (row.n < minSamples) return null;
+
+  const id = ulid();
+  const computed_at = new Date().toISOString();
+  const snap: BaselineSnapshotRow = {
+    id,
+    scope,
+    window_days: windowDays,
+    computed_at,
+    sample_size: row.n,
+    avg_final_score: row.avg_final ?? 0,
+    avg_word_count: row.avg_words ?? 0,
+    avg_severity_hits: row.avg_sev ?? 0,
+  };
+  db.prepare(
+    `INSERT INTO user_baseline_snapshots(id, scope, window_days, computed_at, sample_size,
+                                          avg_final_score, avg_word_count, avg_severity_hits, snapshot_json)
+     VALUES (@id,@scope,@window_days,@computed_at,@sample_size,
+             @avg_final_score,@avg_word_count,@avg_severity_hits,NULL)`
+  ).run(snap);
+  return snap;
+}
+
+export function getLatestBaseline(db: Db, scope = 'global'): BaselineSnapshotRow | null {
+  const row = db
+    .prepare(
+      `SELECT * FROM user_baseline_snapshots WHERE scope = ? ORDER BY computed_at DESC LIMIT 1`
+    )
+    .get(scope) as BaselineSnapshotRow | undefined;
+  return row ?? null;
 }
 
 export function upsertSubagent(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,8 @@ export * from './lang.js';
 export * from './schema.js';
 export * from './db.js';
 export * from './scorer.js';
+export * from './baseline.js';
+export * from './confidence.js';
 export * from './queue.js';
 export * from './backfill.js';
 export * from './analysis.js';

--- a/packages/core/src/migrations/sql.ts
+++ b/packages/core/src/migrations/sql.ts
@@ -211,3 +211,43 @@ CREATE INDEX IF NOT EXISTS idx_deep_created ON deep_analyses(created_at DESC);
 export const MIGRATION_005: string = `
 DROP TABLE IF EXISTS rewrites;
 `;
+
+/**
+ * v0.6.0 schema additions — D-046 asymmetric scoring + confidence + baseline.
+ *
+ * - quality_scores.efficiency_score (INT, nullable) — Phase 1 efficiency axis.
+ * - quality_scores.bonus_score       (INT, nullable) — positive signal bonus applied (0..10).
+ * - quality_scores.cap_applied       (INT, nullable) — if cap floor was triggered, the cap value.
+ * - quality_scores.confidence        (TEXT, nullable) — 'high' | 'medium' | 'low'.
+ * - quality_scores.baseline_delta    (INT, nullable) — final_score - user_baseline (Phase 3).
+ * - user_baseline_snapshots          — rolling-window aggregate per user/scope.
+ *
+ * All columns are nullable so old rows keep working; new scorer always writes them.
+ * See docs/00-decision-log.md D-046 and docs/05-quality-engine.md §3..§6.
+ */
+export const MIGRATION_006: string = `
+ALTER TABLE quality_scores ADD COLUMN efficiency_score INTEGER;
+ALTER TABLE quality_scores ADD COLUMN bonus_score      INTEGER;
+ALTER TABLE quality_scores ADD COLUMN cap_applied      INTEGER;
+ALTER TABLE quality_scores ADD COLUMN confidence       TEXT;
+ALTER TABLE quality_scores ADD COLUMN baseline_delta   INTEGER;
+
+CREATE TABLE IF NOT EXISTS user_baseline_snapshots (
+  id                TEXT PRIMARY KEY,
+  scope             TEXT NOT NULL,          -- 'global' for now; room for per-cwd later
+  window_days       INTEGER NOT NULL,
+  computed_at       DATETIME NOT NULL,
+  sample_size       INTEGER NOT NULL,
+  avg_final_score   REAL NOT NULL,
+  avg_word_count    REAL NOT NULL,
+  avg_severity_hits REAL NOT NULL,
+  snapshot_json     TEXT                    -- reserved for future axes
+);
+CREATE INDEX IF NOT EXISTS idx_baseline_scope ON user_baseline_snapshots(scope, computed_at DESC);
+
+-- prompt_usages gets per-turn efficiency features extracted by the worker.
+-- Kept as a sibling to quality_scores so re-scoring doesn't lose input features.
+ALTER TABLE prompt_usages ADD COLUMN first_shot_success INTEGER;  -- 0|1|null
+ALTER TABLE prompt_usages ADD COLUMN tool_call_count    INTEGER;
+ALTER TABLE prompt_usages ADD COLUMN follow_up_depth    INTEGER;
+`;

--- a/packages/core/src/scorer.ts
+++ b/packages/core/src/scorer.ts
@@ -1,14 +1,26 @@
 /**
- * Quality score computation per docs/05-quality-engine.md §3.
+ * Quality score computation per docs/05-quality-engine.md §3 (D-046).
  *
- * final_score = 0.7 * rule_score + 0.3 * usage_score  (usage available)
- *             = rule_score                            (no usage yet)
+ * D-046 asymmetric + bonus + efficiency + cap model:
  *
- * If judge_score is present:
- *   final_score = 0.5*rule_score + 0.3*usage_score + 0.2*judge_score
- *   (fallback: 0.6/0.4 without usage)
+ *   rule_score  = max(0, 100 - Σ(severity_weight))                    // §3.2
+ *   bonus       = positiveBonus(signals)                              // §3.3  (0..10)
+ *   usage_score = 0.25*fail + 0.20*reuse + 0.10*length                // §3.4
+ *               + 0.25*feedback + 0.20*efficiency  (renormalized)
+ *   raw_final   = compose(rule_score, usage_score, judge_score)       // §3.4
+ *   capped      = applyCap(raw_final + bonus, maxSeverity, sev3Count) // §3.5
+ *   final_score = round(capped)
+ *
+ *   tier        = tierFor(final_score)                                // §3.6 (90/70/50)
+ *
+ * Legacy entry points (computeRuleScore/computeUsageScore/composeFinalScore/tierFor)
+ * keep their original signatures so existing callers (worker) don't break.
  */
 
+// ─── Severity weights ───────────────────────────────────────────────────────
+// D-046 reshuffled severities. Weights reflect the new severity ceiling +
+// bonus + asymmetric cap, so they no longer need to carry all the signal
+// themselves (cap takes over at severity ≥ 4).
 export const SEVERITY_WEIGHT: Record<number, number> = { 1: 2, 2: 5, 3: 10, 4: 18, 5: 30 };
 
 export interface RuleHitLike {
@@ -23,78 +35,211 @@ export function computeRuleScore(hits: RuleHitLike[]): number {
   return Math.max(0, 100 - penalty);
 }
 
+// ─── Positive signal bonus (§3.3, D-046) ────────────────────────────────────
+
+export interface PositiveSignals {
+  hasOutputFormat?: boolean; // +3
+  hasSuccessCriteria?: boolean; // +3
+  hasExample?: boolean; // +2 (only counted when wordCount >= 40)
+  hasFilePathOrVersion?: boolean; // +2
+  wordCount?: number;
+}
+
+export const BONUS_WEIGHTS = {
+  outputFormat: 3,
+  successCriteria: 3,
+  example: 2,
+  pathOrVersion: 2,
+} as const;
+export const BONUS_CAP = 10;
+
+export function positiveBonus(s: PositiveSignals): number {
+  let b = 0;
+  if (s.hasOutputFormat) b += BONUS_WEIGHTS.outputFormat;
+  if (s.hasSuccessCriteria) b += BONUS_WEIGHTS.successCriteria;
+  if (s.hasExample && (s.wordCount ?? 0) >= 40) b += BONUS_WEIGHTS.example;
+  if (s.hasFilePathOrVersion) b += BONUS_WEIGHTS.pathOrVersion;
+  return Math.min(BONUS_CAP, b);
+}
+
+// ─── Usage score with efficiency axis (§3.4, D-046) ─────────────────────────
+
 export interface UsageMetrics {
   toolCalls: number;
   toolFails: number;
-  reuseCount: number; // how many times this prompt_hash seen before in same session
+  reuseCount: number;
   responseLength: number;
   expectedResponseRange?: { min: number; max: number };
   feedbackUps?: number;
   feedbackDowns?: number;
+  /** D-046: first-shot success (0 | 1). */
+  firstShotSuccess?: 0 | 1 | null;
+  /** D-046: total tool_use events triggered by this turn. */
+  turnToolCallCount?: number | null;
+  /** D-046: number of consecutive follow-up turns sharing this intent. */
+  followUpDepth?: number | null;
+}
+
+function toolEconomyScore(calls: number): number {
+  if (calls <= 0) return 100;
+  if (calls <= 3) return 90;
+  if (calls <= 8) return 75;
+  if (calls <= 15) return 50;
+  return 25;
+}
+
+function followUpScore(depth: number): number {
+  if (depth <= 1) return 100;
+  if (depth === 2) return 70;
+  if (depth === 3) return 40;
+  return 20;
+}
+
+/**
+ * Efficiency component of usage_score (0..100). Returns null if none of the
+ * contributing signals are present — lets caller drop it from the weighted
+ * average entirely instead of charging a neutral 75.
+ */
+export function computeEfficiencyScore(m: UsageMetrics): number | null {
+  const hasAny =
+    m.firstShotSuccess != null || m.turnToolCallCount != null || m.followUpDepth != null;
+  if (!hasAny) return null;
+  const fs = m.firstShotSuccess ?? 1;
+  const tc = m.turnToolCallCount ?? 0;
+  const fd = m.followUpDepth ?? 1;
+  const raw = fs * 60 + toolEconomyScore(tc) * 0.3 + followUpScore(fd) * 0.1;
+  return Math.max(0, Math.min(100, Math.round(raw)));
 }
 
 export function computeUsageScore(m: UsageMetrics): number | null {
   const hasFeedback = (m.feedbackUps ?? 0) + (m.feedbackDowns ?? 0) > 0;
-  if (m.toolCalls === 0 && m.responseLength === 0 && m.reuseCount === 0 && !hasFeedback) {
+  const hasEfficiency =
+    m.firstShotSuccess != null || m.turnToolCallCount != null || m.followUpDepth != null;
+  if (
+    m.toolCalls === 0 &&
+    m.responseLength === 0 &&
+    m.reuseCount === 0 &&
+    !hasFeedback &&
+    !hasEfficiency
+  ) {
     return null;
   }
-  // Fail rate (35%)
+
+  // D-046 weights (§3.4):
+  //   fail 0.25 · reuse 0.20 · length 0.10 · feedback 0.25 · efficiency 0.20
+  // Missing components are dropped and weights renormalized so no phantom
+  // neutral "75" leaks into the score.
+  const parts: Array<{ w: number; s: number }> = [];
+
   const failRate = m.toolCalls > 0 ? m.toolFails / m.toolCalls : 0;
-  const failScore = (1 - failRate) * 100;
-  // Reuse (inverse, 25%) — more reuse = lower score
+  parts.push({ w: 0.25, s: (1 - failRate) * 100 });
+
   const reusePenalty = Math.min(1, m.reuseCount / 5);
-  const reuseScore = (1 - reusePenalty) * 100;
-  // Length fit (15%) — if we have expected range; else neutral 75.
-  let lengthScore = 75;
+  parts.push({ w: 0.2, s: (1 - reusePenalty) * 100 });
+
+  // Length fit: only include when an expected range was provided.
   if (m.expectedResponseRange) {
     const { min, max } = m.expectedResponseRange;
+    let lengthScore: number;
     if (m.responseLength >= min && m.responseLength <= max) lengthScore = 100;
     else if (m.responseLength < min)
       lengthScore = Math.max(0, 100 - ((min - m.responseLength) / min) * 100);
     else lengthScore = Math.max(0, 100 - ((m.responseLength - max) / max) * 100);
+    parts.push({ w: 0.1, s: lengthScore });
   }
-  // User feedback (25%) — present only when at least one rating exists.
-  let totalWeight = 0.75;
-  let raw = 0.35 * failScore + 0.25 * reuseScore + 0.15 * lengthScore;
+
   if (hasFeedback) {
     const ups = m.feedbackUps ?? 0;
     const downs = m.feedbackDowns ?? 0;
-    const fbScore = (ups / (ups + downs)) * 100;
-    raw += 0.25 * fbScore;
-    totalWeight = 1.0;
+    parts.push({ w: 0.25, s: (ups / (ups + downs)) * 100 });
   }
-  return Math.round(raw / totalWeight);
+
+  const eff = computeEfficiencyScore(m);
+  if (eff != null) parts.push({ w: 0.2, s: eff });
+
+  const totalWeight = parts.reduce((a, b) => a + b.w, 0);
+  if (totalWeight === 0) return null;
+  const raw = parts.reduce((a, b) => a + b.w * b.s, 0) / totalWeight;
+  return Math.round(raw);
 }
+
+// ─── Cap floor (§3.5, D-046) ───────────────────────────────────────────────
+
+export interface CapInput {
+  maxSeverity: number;
+  severity3Count: number;
+}
+
+export function capFor({ maxSeverity, severity3Count }: CapInput): number {
+  if (maxSeverity >= 5) return 40;
+  if (maxSeverity >= 4) return 60;
+  if (severity3Count >= 2) return 75;
+  return 100;
+}
+
+export function applyCap(score: number, cap: CapInput): { score: number; cap: number } {
+  const c = capFor(cap);
+  return { score: Math.min(score, c), cap: c };
+}
+
+// ─── Tier (§3.6 · D-046 bands 90/70/50) ────────────────────────────────────
+
+export function tierFor(score: number): 'good' | 'ok' | 'weak' | 'bad' {
+  if (score >= 90) return 'good';
+  if (score >= 70) return 'ok';
+  if (score >= 50) return 'weak';
+  return 'bad';
+}
+
+// ─── Compose final score ───────────────────────────────────────────────────
 
 export interface ScoreComposition {
   rule_score: number;
   usage_score: number | null;
   judge_score: number | null;
+  /** D-046: positive signal bonus (0..10). Added after weighted mix, before cap. */
+  bonus?: number;
+  /** D-046: highest severity hit observed; drives the cap floor. */
+  maxSeverity?: number;
+  /** D-046: count of severity-3 hits (for the "two mediums cap at 75" rule). */
+  severity3Count?: number;
 }
 
 export interface ScoreOutcome {
   final_score: number;
   tier: 'good' | 'ok' | 'weak' | 'bad';
+  /** D-046: cap that was applied, if any (null when no cap triggered, i.e. cap=100). */
+  cap?: number | null;
+  /** D-046: bonus actually added. */
+  bonus?: number;
 }
 
 export function composeFinalScore(s: ScoreComposition): ScoreOutcome {
-  let final: number;
+  let mixed: number;
   if (s.judge_score != null && s.usage_score != null) {
-    final = 0.5 * s.rule_score + 0.3 * s.usage_score + 0.2 * s.judge_score;
+    mixed = 0.5 * s.rule_score + 0.3 * s.usage_score + 0.2 * s.judge_score;
   } else if (s.judge_score != null) {
-    final = 0.6 * s.rule_score + 0.4 * s.judge_score;
+    mixed = 0.6 * s.rule_score + 0.4 * s.judge_score;
   } else if (s.usage_score != null) {
-    final = 0.7 * s.rule_score + 0.3 * s.usage_score;
+    mixed = 0.7 * s.rule_score + 0.3 * s.usage_score;
   } else {
-    final = s.rule_score;
+    mixed = s.rule_score;
   }
-  const finalRounded = Math.round(final);
-  return { final_score: finalRounded, tier: tierFor(finalRounded) };
-}
 
-export function tierFor(score: number): 'good' | 'ok' | 'weak' | 'bad' {
-  if (score >= 85) return 'good';
-  if (score >= 65) return 'ok';
-  if (score >= 45) return 'weak';
-  return 'bad';
+  const bonus = s.bonus ?? 0;
+  const withBonus = Math.min(100, mixed + bonus);
+
+  const capInput: CapInput = {
+    maxSeverity: s.maxSeverity ?? 0,
+    severity3Count: s.severity3Count ?? 0,
+  };
+  const { score: capped, cap } = applyCap(withBonus, capInput);
+
+  const finalRounded = Math.round(capped);
+  return {
+    final_score: finalRounded,
+    tier: tierFor(finalRounded),
+    cap: cap < 100 ? cap : null,
+    bonus,
+  };
 }

--- a/packages/core/src/transcript/parser.ts
+++ b/packages/core/src/transcript/parser.ts
@@ -162,3 +162,67 @@ export function summarizeToolUse(events: TranscriptEvent[]): { toolName: string;
   }
   return [...map.entries()].map(([toolName, calls]) => ({ toolName, calls }));
 }
+
+/**
+ * D-046 §3.4.1: per-user-turn efficiency features.
+ *
+ * Walks the transcript in order and, for every `user` event, aggregates:
+ *   - `toolCalls`   — tool_use events that happen before the next user turn
+ *   - `firstShotSuccess` — 1 if the NEXT user turn does not look like a
+ *     correction ("다시/아니/취소/redo/no wait"), 0 otherwise
+ *   - `followUpDepth` — 1 for a fresh user turn, ++ when consecutive
+ *     turns are correction-style (indicating the previous turn did not
+ *     land cleanly)
+ *
+ * Returned in the same order as user turns appear in the transcript so
+ * callers can zip with their own `turn_index` list.
+ */
+const CORRECTION_PATTERN =
+  /(?:^|\s)(다시|아니|취소|재시도|redo|no\s*wait|잘못|wrong|undo)(?:$|\s|[.!?,])/i;
+
+export interface TurnEfficiency {
+  userTurnIndex: number; // index into events[] where the user event lives
+  toolCalls: number;
+  firstShotSuccess: 0 | 1;
+  followUpDepth: number;
+}
+
+export function extractTurnEfficiency(events: TranscriptEvent[]): TurnEfficiency[] {
+  const userIdxs: number[] = [];
+  for (let i = 0; i < events.length; i++) {
+    if (events[i]!.kind === 'user') userIdxs.push(i);
+  }
+
+  const out: TurnEfficiency[] = [];
+  let depth = 1;
+  for (let u = 0; u < userIdxs.length; u++) {
+    const start = userIdxs[u]!;
+    const end = u + 1 < userIdxs.length ? userIdxs[u + 1]! : events.length;
+
+    let toolCalls = 0;
+    for (let j = start + 1; j < end; j++) {
+      if (events[j]!.kind === 'tool_use') toolCalls += 1;
+    }
+
+    // first-shot success = next user turn is NOT a correction.
+    // Last turn defaults to 1 (no evidence of failure).
+    let firstShot: 0 | 1 = 1;
+    if (u + 1 < userIdxs.length) {
+      const nextText = events[userIdxs[u + 1]!]?.text ?? '';
+      if (CORRECTION_PATTERN.test(nextText)) firstShot = 0;
+    }
+
+    out.push({
+      userTurnIndex: start,
+      toolCalls,
+      firstShotSuccess: firstShot,
+      followUpDepth: depth,
+    });
+
+    // If the CURRENT turn was a correction, the NEXT turn's depth grows.
+    const curText = events[start]?.text ?? '';
+    depth = CORRECTION_PATTERN.test(curText) ? depth + 1 : 1;
+  }
+
+  return out;
+}

--- a/packages/core/test/baseline.test.ts
+++ b/packages/core/test/baseline.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  BASELINE_DEFAULT_MIN_SAMPLES,
+  coldStartState,
+  computeDelta,
+  loadBaseline,
+  refreshBaseline,
+} from '../src/baseline.js';
+import { insertPromptUsage, openDb, upsertQualityScore, upsertSession } from '../src/db.js';
+
+describe('computeDelta (D-046 §5.2)', () => {
+  it('null when baseline is absent (cold-start)', () => {
+    expect(computeDelta(80, null)).toBeNull();
+  });
+  it('null when baseline sample is below min threshold', () => {
+    expect(
+      computeDelta(80, {
+        id: 'b1',
+        scope: 'global',
+        window_days: 30,
+        computed_at: '2026-04-24T00:00:00Z',
+        sample_size: 10,
+        avg_final_score: 75,
+        avg_word_count: 20,
+        avg_severity_hits: 1,
+      })
+    ).toBeNull();
+  });
+  it('rounds delta to integer when baseline is active', () => {
+    expect(
+      computeDelta(72, {
+        id: 'b1',
+        scope: 'global',
+        window_days: 30,
+        computed_at: '2026-04-24T00:00:00Z',
+        sample_size: 60,
+        avg_final_score: 78.4,
+        avg_word_count: 20,
+        avg_severity_hits: 1,
+      })
+    ).toBe(-6);
+  });
+});
+
+describe('coldStartState', () => {
+  it('marks cold-start when below threshold', () => {
+    const s = coldStartState(null, 12);
+    expect(s.coldStart).toBe(true);
+    expect(s.need).toBe(BASELINE_DEFAULT_MIN_SAMPLES);
+    expect(s.have).toBe(12);
+  });
+  it('clears cold-start when baseline sample >= min', () => {
+    const s = coldStartState(
+      {
+        id: 'b1',
+        scope: 'global',
+        window_days: 30,
+        computed_at: '2026-04-24T00:00:00Z',
+        sample_size: 120,
+        avg_final_score: 75,
+        avg_word_count: 20,
+        avg_severity_hits: 1,
+      },
+      9999
+    );
+    expect(s.coldStart).toBe(false);
+    expect(s.have).toBe(120);
+  });
+});
+
+describe('refreshBaseline (DB round-trip)', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'tp-baseline-'));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns null when sample size is below minimum', () => {
+    const db = openDb(root);
+    upsertSession(db, { id: 's1', cwd: '/tmp' });
+    const u = insertPromptUsage(db, { session_id: 's1', prompt_text: 'hi' });
+    upsertQualityScore(db, {
+      usage_id: u.id,
+      rule_score: 80,
+      usage_score: null,
+      judge_score: null,
+      final_score: 80,
+      tier: 'ok',
+      rules_version: 1,
+    });
+    const snap = refreshBaseline(db, { minSamples: 50 });
+    expect(snap).toBeNull();
+    expect(loadBaseline(db)).toBeNull();
+  });
+
+  it('persists and returns snapshot when enough samples exist', () => {
+    const db = openDb(root);
+    upsertSession(db, { id: 's1', cwd: '/tmp' });
+    for (let i = 0; i < 6; i++) {
+      const u = insertPromptUsage(db, { session_id: 's1', prompt_text: `prompt ${i}` });
+      upsertQualityScore(db, {
+        usage_id: u.id,
+        rule_score: 80,
+        usage_score: null,
+        judge_score: null,
+        final_score: 70 + i,
+        tier: 'ok',
+        rules_version: 1,
+      });
+    }
+    const snap = refreshBaseline(db, { minSamples: 5 });
+    expect(snap).not.toBeNull();
+    expect(snap!.sample_size).toBe(6);
+    expect(snap!.avg_final_score).toBeCloseTo(72.5, 1);
+    const loaded = loadBaseline(db);
+    expect(loaded?.id).toBe(snap!.id);
+  });
+});

--- a/packages/core/test/confidence.test.ts
+++ b/packages/core/test/confidence.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { LOW_CONFIDENCE_DELTA, computeConfidence } from '../src/confidence.js';
+
+describe('computeConfidence (D-046 §6)', () => {
+  it('low when context is marked unusual', () => {
+    expect(
+      computeConfidence({
+        maxSeverity: 3,
+        hasUsageScore: true,
+        hasJudgeScore: true,
+        contextUnusual: true,
+      })
+    ).toBe('low');
+  });
+
+  it('low when baseline delta is extreme', () => {
+    expect(
+      computeConfidence({
+        maxSeverity: 0,
+        hasUsageScore: true,
+        hasJudgeScore: false,
+        baselineDelta: LOW_CONFIDENCE_DELTA + 5,
+      })
+    ).toBe('low');
+  });
+
+  it('low when only weak rule signals and no usage/judge', () => {
+    expect(
+      computeConfidence({
+        maxSeverity: 1,
+        hasUsageScore: false,
+        hasJudgeScore: false,
+      })
+    ).toBe('low');
+  });
+
+  it('high when severe rule hit + supporting usage signal', () => {
+    expect(
+      computeConfidence({
+        maxSeverity: 4,
+        hasUsageScore: true,
+        hasJudgeScore: false,
+      })
+    ).toBe('high');
+  });
+
+  it('high when clean rule and usage confirms', () => {
+    expect(
+      computeConfidence({
+        maxSeverity: 0,
+        hasUsageScore: true,
+        hasJudgeScore: false,
+      })
+    ).toBe('high');
+  });
+
+  it('medium is the default middle ground', () => {
+    expect(
+      computeConfidence({
+        maxSeverity: 2,
+        hasUsageScore: false,
+        hasJudgeScore: false,
+      })
+    ).toBe('medium');
+  });
+});

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 describe('db', () => {
   it('initializes schema and meta', () => {
     const db = openDb(tmp);
-    expect(getMeta(db, 'schema_version')).toBe('5');
+    expect(getMeta(db, 'schema_version')).toBe('6');
     expect(getMeta(db, 'rules_version')).toBe('1');
     db.close();
   });

--- a/packages/core/test/scorer.test.ts
+++ b/packages/core/test/scorer.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { composeFinalScore, computeRuleScore, computeUsageScore, tierFor } from '../src/scorer.js';
+import {
+  applyCap,
+  capFor,
+  composeFinalScore,
+  computeEfficiencyScore,
+  computeRuleScore,
+  computeUsageScore,
+  positiveBonus,
+  tierFor,
+} from '../src/scorer.js';
 
 describe('computeRuleScore', () => {
   it('100 when no hits', () => {
@@ -15,8 +24,60 @@ describe('computeRuleScore', () => {
   });
 });
 
+describe('positiveBonus (D-046 §3.3)', () => {
+  it('zero when no signals', () => {
+    expect(positiveBonus({})).toBe(0);
+  });
+  it('sums per-signal weights and caps at 10', () => {
+    expect(positiveBonus({ hasOutputFormat: true })).toBe(3);
+    expect(
+      positiveBonus({
+        hasOutputFormat: true,
+        hasSuccessCriteria: true,
+        hasExample: true,
+        hasFilePathOrVersion: true,
+        wordCount: 80,
+      })
+    ).toBe(10);
+  });
+  it('example bonus requires wordCount >= 40', () => {
+    expect(positiveBonus({ hasExample: true, wordCount: 10 })).toBe(0);
+    expect(positiveBonus({ hasExample: true, wordCount: 40 })).toBe(2);
+  });
+});
+
+describe('computeEfficiencyScore (D-046 §3.4.1)', () => {
+  it('null when no efficiency features present', () => {
+    expect(
+      computeEfficiencyScore({ toolCalls: 0, toolFails: 0, reuseCount: 0, responseLength: 0 })
+    ).toBeNull();
+  });
+  it('first-shot success dominates', () => {
+    const hit = computeEfficiencyScore({
+      toolCalls: 0,
+      toolFails: 0,
+      reuseCount: 0,
+      responseLength: 0,
+      firstShotSuccess: 1,
+      turnToolCallCount: 2,
+      followUpDepth: 1,
+    })!;
+    const miss = computeEfficiencyScore({
+      toolCalls: 0,
+      toolFails: 0,
+      reuseCount: 0,
+      responseLength: 0,
+      firstShotSuccess: 0,
+      turnToolCallCount: 2,
+      followUpDepth: 3,
+    })!;
+    expect(hit).toBeGreaterThan(miss);
+    expect(hit).toBeGreaterThanOrEqual(80);
+  });
+});
+
 describe('computeUsageScore', () => {
-  it('null when no signals', () => {
+  it('null when no signals at all', () => {
     expect(
       computeUsageScore({ toolCalls: 0, toolFails: 0, reuseCount: 0, responseLength: 0 })
     ).toBeNull();
@@ -36,11 +97,56 @@ describe('computeUsageScore', () => {
     });
     expect(noFail).toBeGreaterThan(someFail!);
   });
+  it('efficiency rewards a first-shot turn more than a stalled one', () => {
+    // Perfect first-shot (zero tool calls, depth 1) → efficiency = 100.
+    // Stalled turn (16 tool calls, followUp depth 4, failed first shot) →
+    // efficiency drags the score down substantially. The contrast is what
+    // the D-046 efficiency axis is designed to surface.
+    const firstShot = computeUsageScore({
+      toolCalls: 2,
+      toolFails: 0,
+      reuseCount: 0,
+      responseLength: 0,
+      firstShotSuccess: 1,
+      turnToolCallCount: 0,
+      followUpDepth: 1,
+    })!;
+    const stalled = computeUsageScore({
+      toolCalls: 2,
+      toolFails: 0,
+      reuseCount: 0,
+      responseLength: 0,
+      firstShotSuccess: 0,
+      turnToolCallCount: 16,
+      followUpDepth: 4,
+    })!;
+    expect(firstShot).toBeGreaterThan(stalled);
+  });
 });
 
-describe('composeFinalScore', () => {
+describe('capFor / applyCap (D-046 §3.5 — asymmetric cap)', () => {
+  it('severity 5 caps at 40', () => {
+    expect(capFor({ maxSeverity: 5, severity3Count: 0 })).toBe(40);
+    expect(applyCap(95, { maxSeverity: 5, severity3Count: 0 })).toEqual({ score: 40, cap: 40 });
+  });
+  it('severity 4 caps at 60', () => {
+    expect(capFor({ maxSeverity: 4, severity3Count: 0 })).toBe(60);
+    expect(applyCap(95, { maxSeverity: 4, severity3Count: 0 }).score).toBe(60);
+  });
+  it('two severity-3 hits cap at 75', () => {
+    expect(capFor({ maxSeverity: 3, severity3Count: 2 })).toBe(75);
+    expect(applyCap(90, { maxSeverity: 3, severity3Count: 2 }).score).toBe(75);
+  });
+  it('below cap passes through unchanged', () => {
+    expect(applyCap(55, { maxSeverity: 3, severity3Count: 1 })).toEqual({ score: 55, cap: 100 });
+  });
+});
+
+describe('composeFinalScore (D-046)', () => {
   it('uses rule_score when no other signals', () => {
-    expect(composeFinalScore({ rule_score: 80, usage_score: null, judge_score: null })).toEqual({
+    expect(
+      composeFinalScore({ rule_score: 80, usage_score: null, judge_score: null })
+    ).toMatchObject({
       final_score: 80,
       tier: 'ok',
     });
@@ -53,13 +159,51 @@ describe('composeFinalScore', () => {
     const r = composeFinalScore({ rule_score: 80, usage_score: 60, judge_score: 70 });
     expect(r.final_score).toBe(Math.round(0.5 * 80 + 0.3 * 60 + 0.2 * 70));
   });
+  it('adds bonus then caps at 100', () => {
+    const r = composeFinalScore({
+      rule_score: 96,
+      usage_score: null,
+      judge_score: null,
+      bonus: 10,
+    });
+    expect(r.final_score).toBe(100);
+    expect(r.bonus).toBe(10);
+  });
+  it('severity-5 cap overrides otherwise-perfect score', () => {
+    // Rule score stays at 70 (one severity-5 hit -30), usage_score high, but cap=40.
+    const r = composeFinalScore({
+      rule_score: 70,
+      usage_score: 95,
+      judge_score: null,
+      bonus: 5,
+      maxSeverity: 5,
+      severity3Count: 0,
+    });
+    expect(r.final_score).toBeLessThanOrEqual(40);
+    expect(r.tier).toBe('bad');
+    expect(r.cap).toBe(40);
+  });
+  it('positive bonus lifts a clean prompt into good tier', () => {
+    // Clean rule (100) + null usage + bonus 8 → 100, good.
+    const r = composeFinalScore({
+      rule_score: 100,
+      usage_score: null,
+      judge_score: null,
+      bonus: 8,
+    });
+    expect(r.tier).toBe('good');
+  });
 });
 
-describe('tierFor', () => {
-  it('maps to tiers', () => {
+describe('tierFor (D-046 bands 90/70/50)', () => {
+  it('maps to new bands', () => {
     expect(tierFor(95)).toBe('good');
+    expect(tierFor(90)).toBe('good');
+    expect(tierFor(89)).toBe('ok');
     expect(tierFor(70)).toBe('ok');
+    expect(tierFor(69)).toBe('weak');
     expect(tierFor(50)).toBe('weak');
-    expect(tierFor(30)).toBe('bad');
+    expect(tierFor(49)).toBe('bad');
+    expect(tierFor(0)).toBe('bad');
   });
 });

--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -240,6 +240,52 @@ export function tierBadge(tier: string, locale: Locale = 'en'): string {
   return `<span aria-label="${escapeHtml(ariaLabel)}" class="inline-block px-2 py-0.5 text-[11px] font-mono font-semibold tracking-wider uppercase rounded ${cls}">${escapeHtml(display)}</span>`;
 }
 
+/**
+ * D-046 §6 — confidence signaling badge.
+ *
+ * Rendered next to the tier badge on the detail hero and (smaller) beside
+ * list rows. The mark is deliberately ASCII so it reads the same across all
+ * 5 locales; the aria-label exists only for accessibility.
+ *
+ *   high   → "● HIGH"
+ *   medium → "○ MED"
+ *   low    → "○ LOW · for reference"  (the "참고용" cue is the whole point)
+ */
+export function confidenceBadge(
+  confidence: string | null | undefined,
+  locale: Locale = 'en'
+): string {
+  const label = (confidence ?? '').toLowerCase();
+  if (label !== 'high' && label !== 'medium' && label !== 'low') return '';
+  const mark = label === 'high' ? '●' : '○';
+  const display = label === 'medium' ? 'MED' : label.toUpperCase();
+  const cls =
+    label === 'high'
+      ? 'text-emerald-700 dark:text-emerald-300'
+      : label === 'low'
+        ? 'text-gray-500 dark:text-zinc-400'
+        : 'text-gray-600 dark:text-zinc-300';
+  const suffix = label === 'low' ? (locale === 'ko' ? ' · 참고용' : ' · for reference') : '';
+  const aria = `confidence: ${label}`;
+  return `<span aria-label="${escapeHtml(aria)}" class="inline-flex items-center gap-1 text-[11px] font-mono uppercase tracking-wider ${cls}">${mark} ${escapeHtml(display + suffix)}</span>`;
+}
+
+/**
+ * D-046 §5 — baseline delta micro-line.
+ * Returns "" when delta is null (cold-start or not yet computed).
+ */
+export function baselineDeltaLine(
+  delta: number | null | undefined,
+  avg: number | null | undefined,
+  locale: Locale = 'en'
+): string {
+  if (delta == null || avg == null) return '';
+  const sign = delta > 0 ? '+' : '';
+  const vs = locale === 'ko' ? `내 평균 ${avg.toFixed(0)} 대비` : `vs your avg ${avg.toFixed(0)}`;
+  const tone = delta > 2 ? 'text-emerald-600' : delta < -2 ? 'text-red-600' : 'text-gray-500';
+  return `<span class="text-[11px] font-mono ${tone}">${vs} <strong>${sign}${delta}</strong></span>`;
+}
+
 export interface DailyBucket {
   day: string;
   good: number;

--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -141,23 +141,38 @@ function renderLanguageSwitcher(locale: Locale, opts: LayoutOptions): string {
   const queryPrefix = new URLSearchParams(passthrough).toString();
   const sep = queryPrefix ? '&' : '';
 
+  // D-047 follow-up: native <select> used to spawn an OS dropdown whose
+  // popup ignored our viewport — in embedded browsers (VS Code terminal
+  // preview, small iframe) it overflowed the terminal area and was clipped.
+  // Replaced with a `<details>/<summary>` disclosure rendering the options
+  // as a grid inside an absolutely-positioned panel we CAN size. right-0
+  // anchors the panel to the header's right edge; max-h + overflow-auto
+  // keeps it inside the viewport at the tiniest terminal size.
   const options = (['en', 'ko', 'zh', 'es', 'ja'] as Locale[])
     .map((code) => {
       const url = `${basePath}?${queryPrefix}${sep}lang=${code}`;
-      const selected = code === locale ? ' selected' : '';
-      return `<option value="${escapeHtml(url)}"${selected}>${escapeHtml(LOCALE_LABELS[code])}</option>`;
+      const isCurrent = code === locale;
+      const cls = isCurrent
+        ? 'bg-accent/10 text-accent font-semibold'
+        : 'text-gray-700 dark:text-zinc-200 hover:bg-gray-100 dark:hover:bg-zinc-700';
+      return `<a role="menuitemradio" aria-checked="${isCurrent}" href="${escapeHtml(url)}" class="block px-3 py-1.5 text-sm rounded ${cls}">${escapeHtml(LOCALE_LABELS[code])}</a>`;
     })
     .join('');
 
-  return `<label class="text-xs text-gray-500 flex items-center gap-2">
-    <span class="sr-only">${escapeHtml(t(locale, 'common.language'))}</span>
-    <select
-      class="text-xs border border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 rounded px-2 py-1"
-      onchange="window.location=this.value"
-      aria-label="${escapeHtml(t(locale, 'common.language'))}">
+  const current = LOCALE_LABELS[locale];
+  const languageLabel = escapeHtml(t(locale, 'common.language'));
+
+  return `<details class="relative group" aria-label="${languageLabel}">
+    <summary class="cursor-pointer select-none list-none text-xs text-gray-500 hover:text-accent flex items-center gap-1 rounded px-2 py-1 border border-transparent hover:border-gray-200 dark:hover:border-zinc-600">
+      <span class="sr-only">${languageLabel}</span>
+      <span aria-hidden="true">🌐</span>
+      <span>${escapeHtml(current)}</span>
+      <span class="text-[8px] opacity-60 group-open:rotate-180 transition-transform" aria-hidden="true">▼</span>
+    </summary>
+    <div role="menu" class="absolute right-0 mt-1 py-1 px-1 bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-lg shadow-lg z-50 w-40 max-h-[70vh] overflow-auto space-y-0.5">
       ${options}
-    </select>
-  </label>`;
+    </div>
+  </details>`;
 }
 
 /**

--- a/packages/dashboard/src/i18n.ts
+++ b/packages/dashboard/src/i18n.ts
@@ -92,6 +92,7 @@ export interface Dictionary {
   'overview.patterns_to_watch': string;
   'overview.patterns_window': string;
   'overview.patterns_empty': string;
+  'overview.calibrating': string;
 
   /* prompts list */
   'prompts.title': string;
@@ -203,6 +204,7 @@ const EN: Dictionary = {
   'overview.patterns_to_watch': 'Patterns to watch',
   'overview.patterns_window': 'last 30 days',
   'overview.patterns_empty': 'No recurring patterns — you are doing great.',
+  'overview.calibrating': 'Calibrating your baseline… {have}/{need} turns',
 
   'prompts.title': 'Prompts',
   'prompts.all_tiers': 'All tiers',
@@ -307,6 +309,7 @@ const KO: Dictionary = {
   'overview.patterns_to_watch': '자주 걸리는 패턴',
   'overview.patterns_window': '지난 30일',
   'overview.patterns_empty': '최근 30일 반복 패턴 없음 — 잘하고 계세요.',
+  'overview.calibrating': '당신의 기준선 학습 중… {have}/{need}턴',
 
   'prompts.title': '프롬프트',
   'prompts.all_tiers': '모든 등급',
@@ -411,6 +414,7 @@ const ZH: Dictionary = {
   'overview.patterns_to_watch': '常见问题模式',
   'overview.patterns_window': '过去 30 天',
   'overview.patterns_empty': '过去 30 天无重复模式 — 做得很好。',
+  'overview.calibrating': '正在校准您的基线… {have}/{need} 轮',
 
   'prompts.title': '提示',
   'prompts.all_tiers': '所有等级',
@@ -515,6 +519,7 @@ const ES: Dictionary = {
   'overview.patterns_to_watch': 'Patrones a vigilar',
   'overview.patterns_window': 'últimos 30 días',
   'overview.patterns_empty': 'Sin patrones recurrentes — lo estás haciendo bien.',
+  'overview.calibrating': 'Calibrando tu línea base… {have}/{need} turnos',
 
   'prompts.title': 'Prompts',
   'prompts.all_tiers': 'Todos los niveles',
@@ -619,6 +624,7 @@ const JA: Dictionary = {
   'overview.patterns_to_watch': '繰り返しのパターン',
   'overview.patterns_window': '直近 30 日',
   'overview.patterns_empty': '直近 30 日の繰り返しパターンなし — 順調です。',
+  'overview.calibrating': 'あなたの基準線を学習中… {have}/{need} ターン',
 
   'prompts.title': 'プロンプト',
   'prompts.all_tiers': 'すべての品質',

--- a/packages/dashboard/src/i18n.ts
+++ b/packages/dashboard/src/i18n.ts
@@ -107,6 +107,7 @@ export interface Dictionary {
   'prompts.col.hits': string;
   'prompts.col.prompt': string;
   'prompts.col.created': string;
+  'prompts.hint_more': string;
 
   /* prompt detail */
   'detail.title': string;
@@ -218,6 +219,7 @@ const EN: Dictionary = {
   'prompts.col.hits': 'Hits',
   'prompts.col.prompt': 'Prompt',
   'prompts.col.created': 'Created',
+  'prompts.hint_more': 'more',
 
   'detail.title': 'Prompt',
   'detail.session': 'session',
@@ -323,6 +325,7 @@ const KO: Dictionary = {
   'prompts.col.hits': '히트',
   'prompts.col.prompt': '프롬프트',
   'prompts.col.created': '생성',
+  'prompts.hint_more': '더',
 
   'detail.title': '프롬프트',
   'detail.session': '세션',
@@ -428,6 +431,7 @@ const ZH: Dictionary = {
   'prompts.col.hits': '命中',
   'prompts.col.prompt': '提示',
   'prompts.col.created': '创建',
+  'prompts.hint_more': '项',
 
   'detail.title': '提示',
   'detail.session': '会话',
@@ -533,6 +537,7 @@ const ES: Dictionary = {
   'prompts.col.hits': 'Aciertos',
   'prompts.col.prompt': 'Prompt',
   'prompts.col.created': 'Creado',
+  'prompts.hint_more': 'más',
 
   'detail.title': 'Prompt',
   'detail.session': 'sesión',
@@ -638,6 +643,7 @@ const JA: Dictionary = {
   'prompts.col.hits': 'ヒット',
   'prompts.col.prompt': 'プロンプト',
   'prompts.col.created': '作成',
+  'prompts.hint_more': '件',
 
   'detail.title': 'プロンプト',
   'detail.session': 'セッション',

--- a/packages/dashboard/src/i18n.ts
+++ b/packages/dashboard/src/i18n.ts
@@ -107,7 +107,6 @@ export interface Dictionary {
   'prompts.col.hits': string;
   'prompts.col.prompt': string;
   'prompts.col.created': string;
-  'prompts.hint_more': string;
 
   /* prompt detail */
   'detail.title': string;
@@ -219,7 +218,6 @@ const EN: Dictionary = {
   'prompts.col.hits': 'Hits',
   'prompts.col.prompt': 'Prompt',
   'prompts.col.created': 'Created',
-  'prompts.hint_more': 'more',
 
   'detail.title': 'Prompt',
   'detail.session': 'session',
@@ -325,7 +323,6 @@ const KO: Dictionary = {
   'prompts.col.hits': '히트',
   'prompts.col.prompt': '프롬프트',
   'prompts.col.created': '생성',
-  'prompts.hint_more': '더',
 
   'detail.title': '프롬프트',
   'detail.session': '세션',
@@ -431,7 +428,6 @@ const ZH: Dictionary = {
   'prompts.col.hits': '命中',
   'prompts.col.prompt': '提示',
   'prompts.col.created': '创建',
-  'prompts.hint_more': '项',
 
   'detail.title': '提示',
   'detail.session': '会话',
@@ -537,7 +533,6 @@ const ES: Dictionary = {
   'prompts.col.hits': 'Aciertos',
   'prompts.col.prompt': 'Prompt',
   'prompts.col.created': 'Creado',
-  'prompts.hint_more': 'más',
 
   'detail.title': 'Prompt',
   'detail.session': 'sesión',
@@ -643,7 +638,6 @@ const JA: Dictionary = {
   'prompts.col.hits': 'ヒット',
   'prompts.col.prompt': 'プロンプト',
   'prompts.col.created': '作成',
-  'prompts.hint_more': '件',
 
   'detail.title': 'プロンプト',
   'detail.session': 'セッション',

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -15,6 +15,8 @@ import {
 import { getRulesCatalog } from '@think-prompt/rules';
 import Fastify, { type FastifyInstance, type FastifyRequest } from 'fastify';
 import {
+  baselineDeltaLine,
+  confidenceBadge,
   escapeHtml,
   layout,
   renderDailyChart,
@@ -317,8 +319,19 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
 
     const chartHtml = renderDailyChart(days);
 
+    // D-046 §8 cold-start: show "calibrating… N/50" banner while personal
+    // baseline isn't yet usable. Hidden once enough data accumulates.
+    const BASELINE_MIN = 50;
+    const baselineBanner =
+      totals.c < BASELINE_MIN
+        ? `<div class="mb-6 rounded-xl border border-dashed border-gray-300 dark:border-zinc-600 bg-gray-50 dark:bg-zinc-800/60 px-4 py-3 text-sm text-gray-600 dark:text-zinc-300">${escapeHtml(
+            t(locale, 'overview.calibrating', { have: totals.c, need: BASELINE_MIN })
+          )}</div>`
+        : '';
+
     const body = `
       <h1 class="text-2xl font-bold mb-6">${escapeHtml(t(locale, 'overview.title'))}</h1>
+      ${baselineBanner}
       <section aria-label="${escapeHtml(t(locale, 'overview.tier_breakdown'))}" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
         <div class="bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700 shadow-sm p-5">
           <div class="text-[10px] text-gray-500 uppercase tracking-widest font-mono font-semibold">${escapeHtml(t(locale, 'overview.total_prompts'))}</div>
@@ -575,8 +588,20 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
           judge_score: number | null;
           final_score: number;
           tier: string;
+          confidence: string | null;
+          baseline_delta: number | null;
+          efficiency_score: number | null;
+          bonus_score: number | null;
+          cap_applied: number | null;
         }
       | undefined;
+
+    // D-046: pull latest baseline average so we can render "vs your avg N".
+    const baselineRow = db
+      .prepare(
+        `SELECT avg_final_score FROM user_baseline_snapshots ORDER BY computed_at DESC LIMIT 1`
+      )
+      .get() as { avg_final_score: number } | undefined;
     const hits = db
       .prepare(`SELECT * FROM rule_hits WHERE usage_id=? ORDER BY severity DESC`)
       .all(id) as Array<{ rule_id: string; severity: number; message: string }>;
@@ -654,13 +679,17 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
             <div class="text-sm text-gray-400 font-mono">/100</div>
           </div>
           <div class="flex-1 min-w-[16rem]">
-            <div class="mb-2">${score ? tierBadge(score.tier, locale) : ''}</div>
+            <div class="mb-2 flex items-center gap-2 flex-wrap">
+              ${score ? tierBadge(score.tier, locale) : ''}
+              ${score ? confidenceBadge(score.confidence, locale) : ''}
+              ${score ? baselineDeltaLine(score.baseline_delta, baselineRow?.avg_final_score ?? null, locale) : ''}
+            </div>
             <div class="text-sm text-gray-700 dark:text-zinc-200 leading-relaxed">${escapeHtml(diagnosisLine)}</div>
           </div>
         </div>
         ${
           score
-            ? `<div class="mt-5 pt-5 border-t border-gray-100 dark:border-zinc-700 text-xs text-gray-400">rule ${score.rule_score} · usage ${score.usage_score ?? '–'} · judge ${score.judge_score ?? '–'}</div>`
+            ? `<div class="mt-5 pt-5 border-t border-gray-100 dark:border-zinc-700 text-xs text-gray-400">rule ${score.rule_score} · usage ${score.usage_score ?? '–'} · judge ${score.judge_score ?? '–'} · eff ${score.efficiency_score ?? '–'} · bonus ${score.bonus_score ?? 0}${score.cap_applied != null ? ` · cap ${score.cap_applied}` : ''}</div>`
             : ''
         }
       </section>

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -537,11 +537,12 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         <tbody>
           ${rows
             .map((r) => {
-              // D-046 follow-up: render EVERY rule-hit message verbatim
-              // (same wording as the detail page's "What went wrong"
-              // section) so users can scan the issues without drilling
-              // in. Previous behaviour showed only the shortTip for
-              // top_rule_id — users asked for the full catalogue.
+              // D-046 follow-up v2: show the highest-severity rule-hit
+              // message verbatim on ONE line, plus a compact "+N 더" badge
+              // when there are more. Keeps row height capped at two lines
+              // (snippet + hint) while still using the same wording as the
+              // detail page. Full list is one click away — the row is
+              // already clickable to the detail page's "What went wrong".
               let hitMessages: string[] = [];
               if (r.hit_messages_json) {
                 try {
@@ -552,18 +553,17 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                     );
                   }
                 } catch {
-                  // Malformed JSON from the aggregate — silently skip the
-                  // hint block rather than throw, the row is still usable.
+                  // Malformed aggregate — skip the hint rather than throw.
                 }
               }
+              const extraCount = Math.max(0, hitMessages.length - 1);
+              const extraBadge =
+                extraCount > 0
+                  ? ` <span class="not-italic ml-1 inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono font-medium rounded bg-gray-100 dark:bg-zinc-700 text-gray-600 dark:text-zinc-300 align-middle">+${extraCount} ${escapeHtml(t(locale, 'prompts.hint_more'))}</span>`
+                  : '';
               const hintLine =
                 hitMessages.length > 0
-                  ? `<div class="mt-1 space-y-0.5">${hitMessages
-                      .map(
-                        (m) =>
-                          `<div class="text-xs text-gray-600 dark:text-zinc-400 italic leading-snug break-words">→ ${escapeHtml(m)}</div>`
-                      )
-                      .join('')}</div>`
+                  ? `<div class="text-xs text-gray-600 dark:text-zinc-400 italic leading-snug mt-0.5 truncate">→ ${escapeHtml(hitMessages[0]!)}${extraBadge}</div>`
                   : '';
               return `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}?lang=${locale}'">
                    <td class="p-2 text-gray-500 text-xs font-mono whitespace-nowrap align-top">${escapeHtml(formatLocalDateTime(r.created_at, locale))}</td>
@@ -644,16 +644,6 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
     const consentState = currentConfig.analysis.deep_consent;
     const analyzeEnabled = currentConfig.llm.enabled && consentState === 'granted';
 
-    // ----- Build a one-line diagnosis from the top 2 hits (highest severity) -----
-    // The rule engine already sorted hits DESC by severity. Take the first
-    // two messages and join with " · " — one compact sentence that explains
-    // WHY this score, which is what the user most needs above the fold.
-    const topHits = hits.slice(0, 2);
-    const diagnosisLine =
-      topHits.length === 0
-        ? t(locale, 'detail.no_issues_found')
-        : topHits.map((h) => h.message.trim()).join(' · ');
-
     // ----- Severity → color class for the left accent bar of lesson cards --
     const sevBar = (sev: number): string => {
       if (sev >= 3) return 'bg-red-500';
@@ -708,12 +698,16 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
             <div class="text-sm text-gray-400 font-mono">/100</div>
           </div>
           <div class="flex-1 min-w-[16rem]">
-            <div class="mb-2 flex items-center gap-2 flex-wrap">
+            <div class="flex items-center gap-2 flex-wrap">
               ${score ? tierBadge(score.tier, locale) : ''}
               ${score ? confidenceBadge(score.confidence, locale) : ''}
               ${score ? baselineDeltaLine(score.baseline_delta, baselineRow?.avg_final_score ?? null, locale) : ''}
             </div>
-            <div class="text-sm text-gray-700 dark:text-zinc-200 leading-relaxed">${escapeHtml(diagnosisLine)}</div>
+            ${
+              hits.length === 0
+                ? `<div class="text-sm text-gray-500 dark:text-zinc-400 leading-relaxed mt-2">${escapeHtml(t(locale, 'detail.no_issues_found'))}</div>`
+                : ''
+            }
           </div>
         </div>
         ${

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -458,7 +458,18 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                 (SELECT rule_id FROM rule_hits rh
                   WHERE rh.usage_id = pu.id
                   ORDER BY rh.severity DESC, rh.rule_id ASC
-                  LIMIT 1) AS top_rule_id
+                  LIMIT 1) AS top_rule_id,
+                -- D-046 follow-up: surface ALL rule-hit messages on the
+                -- Prompts list so users see the same verbatim wording as
+                -- on the detail page's "What went wrong" section. json
+                -- array preserves order (severity DESC, rule_id ASC).
+                (SELECT json_group_array(message)
+                   FROM (
+                     SELECT message FROM rule_hits rh2
+                      WHERE rh2.usage_id = pu.id
+                      ORDER BY rh2.severity DESC, rh2.rule_id ASC
+                   )
+                ) AS hit_messages_json
            FROM prompt_usages pu
            LEFT JOIN quality_scores qs ON qs.usage_id = pu.id
            LEFT JOIN sessions s ON s.id = pu.session_id
@@ -475,6 +486,7 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
       source: string;
       hits: number;
       top_rule_id: string | null;
+      hit_messages_json: string | null;
     }>;
 
     const sourceOptions = [
@@ -525,17 +537,34 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         <tbody>
           ${rows
             .map((r) => {
-              // Inline improvement hint — shown whenever the row has at
-              // least one rule hit, any tier. D-045 supersedes D-043's
-              // weak/bad-only restriction: good-tier rows with no hits
-              // stay single-line naturally (top_rule_id = null), while
-              // ok/weak/bad rows gain one line of "what to improve next
-              // time" so users can scan the whole list without drilling in.
-              const shortTip =
-                locale === 'ko' && r.top_rule_id ? getRuleShortTipKo(r.top_rule_id) : null;
-              const hintLine = shortTip
-                ? `<div class="text-xs text-gray-500 dark:text-zinc-400 italic mt-0.5 truncate">→ ${escapeHtml(shortTip)}</div>`
-                : '';
+              // D-046 follow-up: render EVERY rule-hit message verbatim
+              // (same wording as the detail page's "What went wrong"
+              // section) so users can scan the issues without drilling
+              // in. Previous behaviour showed only the shortTip for
+              // top_rule_id — users asked for the full catalogue.
+              let hitMessages: string[] = [];
+              if (r.hit_messages_json) {
+                try {
+                  const parsed = JSON.parse(r.hit_messages_json) as unknown;
+                  if (Array.isArray(parsed)) {
+                    hitMessages = parsed.filter(
+                      (m): m is string => typeof m === 'string' && m.length > 0
+                    );
+                  }
+                } catch {
+                  // Malformed JSON from the aggregate — silently skip the
+                  // hint block rather than throw, the row is still usable.
+                }
+              }
+              const hintLine =
+                hitMessages.length > 0
+                  ? `<div class="mt-1 space-y-0.5">${hitMessages
+                      .map(
+                        (m) =>
+                          `<div class="text-xs text-gray-600 dark:text-zinc-400 italic leading-snug break-words">→ ${escapeHtml(m)}</div>`
+                      )
+                      .join('')}</div>`
+                  : '';
               return `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}?lang=${locale}'">
                    <td class="p-2 text-gray-500 text-xs font-mono whitespace-nowrap align-top">${escapeHtml(formatLocalDateTime(r.created_at, locale))}</td>
                    <td class="p-2 font-mono align-top">${r.score >= 0 ? r.score : '-'}</td>

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -537,12 +537,10 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
         <tbody>
           ${rows
             .map((r) => {
-              // D-046 follow-up v2: show the highest-severity rule-hit
-              // message verbatim on ONE line, plus a compact "+N 더" badge
-              // when there are more. Keeps row height capped at two lines
-              // (snippet + hint) while still using the same wording as the
-              // detail page. Full list is one click away — the row is
-              // already clickable to the detail page's "What went wrong".
+              // D-046 follow-up v3: render every rule-hit message verbatim
+              // as its own "→ …" line (severity DESC order). Same wording
+              // as the detail page's "What went wrong" section. No badge,
+              // no truncation — full text wraps within the cell.
               let hitMessages: string[] = [];
               if (r.hit_messages_json) {
                 try {
@@ -556,14 +554,14 @@ export function buildDashboardServer(deps: DashboardDeps = {}): FastifyInstance 
                   // Malformed aggregate — skip the hint rather than throw.
                 }
               }
-              const extraCount = Math.max(0, hitMessages.length - 1);
-              const extraBadge =
-                extraCount > 0
-                  ? ` <span class="not-italic ml-1 inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono font-medium rounded bg-gray-100 dark:bg-zinc-700 text-gray-600 dark:text-zinc-300 align-middle">+${extraCount} ${escapeHtml(t(locale, 'prompts.hint_more'))}</span>`
-                  : '';
               const hintLine =
                 hitMessages.length > 0
-                  ? `<div class="text-xs text-gray-600 dark:text-zinc-400 italic leading-snug mt-0.5 truncate">→ ${escapeHtml(hitMessages[0]!)}${extraBadge}</div>`
+                  ? `<div class="mt-1 space-y-0.5">${hitMessages
+                      .map(
+                        (m) =>
+                          `<div class="text-xs text-gray-600 dark:text-zinc-400 italic leading-snug break-words">→ ${escapeHtml(m)}</div>`
+                      )
+                      .join('')}</div>`
                   : '';
               return `<tr class="border-t border-gray-100 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer" onclick="location.href='/prompts/${r.id}?lang=${locale}'">
                    <td class="p-2 text-gray-500 text-xs font-mono whitespace-nowrap align-top">${escapeHtml(formatLocalDateTime(r.created_at, locale))}</td>

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -885,42 +885,55 @@ describe('Prompts list · inline hints (full rule messages)', () => {
     return { id: u.id };
   }
 
-  it('renders ALL rule-hit messages verbatim on weak-tier rows', async () => {
+  it('renders only the highest-severity message plus a "+N more" badge', async () => {
+    // 3 hits → the row shows the top-severity message inline and a compact
+    // "+2 더" badge. The other two messages are NOT rendered inline (users
+    // click through to the detail page for the full list) — this keeps the
+    // table row height capped at two lines.
     await seedPromptWithHits('weak', [
       { rule_id: 'R002', severity: 3, message: '출력 형식이 지정되지 않았습니다.' },
+      { rule_id: 'R006', severity: 2, message: '성공 기준이 없습니다.' },
       { rule_id: 'R010', severity: 1, message: '출력 제약(길이/언어/범위)이 없습니다.' },
     ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
     expect(res.statusCode).toBe(200);
+    // Top message rendered verbatim.
     expect(res.body).toContain('→ 출력 형식이 지정되지 않았습니다.');
-    expect(res.body).toContain('→ 출력 제약(길이/언어/범위)이 없습니다.');
+    // Badge shows +2 더 (two additional hits beyond the first).
+    expect(res.body).toContain('+2 더');
+    // Lower-severity messages are NOT inlined on the list.
+    expect(res.body).not.toContain('→ 성공 기준이 없습니다.');
+    expect(res.body).not.toContain('→ 출력 제약(길이/언어/범위)이 없습니다.');
     await app.close();
   });
 
-  it('renders the hint on good-tier rows that still carry a hit', async () => {
+  it('omits the badge when there is only one hit', async () => {
     await seedPromptWithHits('good', [
       { rule_id: 'R001', severity: 1, message: '프롬프트가 너무 짧습니다.' },
     ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
     expect(res.body).toContain('→ 프롬프트가 너무 짧습니다.');
+    // No badge counter when only 1 hit.
+    expect(res.body).not.toMatch(/\+\d+ 더/);
     await app.close();
   });
 
-  it('orders messages by severity DESC (high-severity hit shown before low)', async () => {
-    // Seed two hits on the same usage — severity 4 should appear before
-    // severity 1 in the rendered HTML.
+  it('picks the highest-severity message as the inline one', async () => {
+    // Seed with the lower-severity rule listed first to confirm ordering
+    // comes from the query (severity DESC, rule_id ASC), not insertion
+    // order.
     await seedPromptWithHits('bad', [
-      { rule_id: 'R004', severity: 4, message: 'HIGH-SEVERITY-MARKER' },
       { rule_id: 'R001', severity: 1, message: 'LOW-SEVERITY-MARKER' },
+      { rule_id: 'R004', severity: 4, message: 'HIGH-SEVERITY-MARKER' },
     ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    const hi = res.body.indexOf('HIGH-SEVERITY-MARKER');
-    const lo = res.body.indexOf('LOW-SEVERITY-MARKER');
-    expect(hi).toBeGreaterThan(-1);
-    expect(lo).toBeGreaterThan(hi);
+    // HIGH-SEVERITY is the inline arrow, LOW-SEVERITY is absorbed into +1.
+    expect(res.body).toContain('→ HIGH-SEVERITY-MARKER');
+    expect(res.body).toContain('+1 더');
+    expect(res.body).not.toContain('→ LOW-SEVERITY-MARKER');
     await app.close();
   });
 

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -856,11 +856,14 @@ describe('dashboard favicon', () => {
   });
 });
 
-// Inline improvement hint on Prompts list rows (D-043).
-describe('Prompts list · inline hint (weak/bad KO)', () => {
-  async function seedPromptWithHit(
+// Inline improvement hint on Prompts list rows (D-043 → D-046 follow-up).
+// D-046: the inline hint now surfaces EVERY rule-hit message verbatim (same
+// wording as the detail page's "What went wrong" section), regardless of
+// locale. Tier-gated shortTip UX was replaced per user request.
+describe('Prompts list · inline hints (full rule messages)', () => {
+  async function seedPromptWithHits(
     tier: 'good' | 'ok' | 'weak' | 'bad',
-    ruleId: string
+    hits: Array<{ rule_id: string; severity: number; message: string }>
   ): Promise<{ id: string }> {
     const db = openDb();
     upsertSession(db, { id: `s-${tier}`, cwd: '/tmp' });
@@ -875,57 +878,63 @@ describe('Prompts list · inline hint (weak/bad KO)', () => {
       tier,
       rules_version: 1,
     });
-    insertRuleHit(db, {
-      usage_id: u.id,
-      rule_id: ruleId,
-      severity: 3,
-      message: 'test',
-    });
+    for (const h of hits) {
+      insertRuleHit(db, { usage_id: u.id, ...h });
+    }
     db.close();
     return { id: u.id };
   }
 
-  it('renders "→ shortTip" under weak-tier prompt rows (KO)', async () => {
-    await seedPromptWithHit('weak', 'R004');
+  it('renders ALL rule-hit messages verbatim on weak-tier rows', async () => {
+    await seedPromptWithHits('weak', [
+      { rule_id: 'R002', severity: 3, message: '출력 형식이 지정되지 않았습니다.' },
+      { rule_id: 'R010', severity: 1, message: '출력 제약(길이/언어/범위)이 없습니다.' },
+    ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
     expect(res.statusCode).toBe(200);
-    // R004 shortTip = "한 번에 한 가지만 부탁하세요."
-    expect(res.body).toContain('한 번에 한 가지만 부탁하세요');
-    expect(res.body).toMatch(/→ 한 번에 한 가지만/);
+    expect(res.body).toContain('→ 출력 형식이 지정되지 않았습니다.');
+    expect(res.body).toContain('→ 출력 제약(길이/언어/범위)이 없습니다.');
     await app.close();
   });
 
-  it('renders "→ shortTip" under bad-tier prompt rows (KO)', async () => {
-    await seedPromptWithHit('bad', 'R010');
+  it('renders the hint on good-tier rows that still carry a hit', async () => {
+    await seedPromptWithHits('good', [
+      { rule_id: 'R001', severity: 1, message: '프롬프트가 너무 짧습니다.' },
+    ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    // R010 shortTip = "길이 · 언어 · 범위 제약을 한 줄 추가하세요."
-    expect(res.body).toContain('길이 · 언어 · 범위 제약을 한 줄 추가하세요');
+    expect(res.body).toContain('→ 프롬프트가 너무 짧습니다.');
     await app.close();
   });
 
-  // D-045 supersedes D-043's weak/bad-only restriction. Any row with a
-  // rule hit now shows its shortTip, regardless of tier — so users can
-  // scan the list and see "what to improve next time" for every
-  // imperfect prompt, not just the worst ones.
-  it('renders hint for good-tier rows that still have a rule hit', async () => {
-    await seedPromptWithHit('good', 'R004');
+  it('orders messages by severity DESC (high-severity hit shown before low)', async () => {
+    // Seed two hits on the same usage — severity 4 should appear before
+    // severity 1 in the rendered HTML.
+    await seedPromptWithHits('bad', [
+      { rule_id: 'R004', severity: 4, message: 'HIGH-SEVERITY-MARKER' },
+      { rule_id: 'R001', severity: 1, message: 'LOW-SEVERITY-MARKER' },
+    ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    expect(res.body).toContain('→ 한 번에 한 가지만');
+    const hi = res.body.indexOf('HIGH-SEVERITY-MARKER');
+    const lo = res.body.indexOf('LOW-SEVERITY-MARKER');
+    expect(hi).toBeGreaterThan(-1);
+    expect(lo).toBeGreaterThan(hi);
     await app.close();
   });
 
-  it('renders hint for ok-tier rows', async () => {
-    await seedPromptWithHit('ok', 'R004');
+  it('renders messages in every locale (no KO-only gate)', async () => {
+    await seedPromptWithHits('weak', [
+      { rule_id: 'R002', severity: 3, message: 'Output format not specified.' },
+    ]);
     const app = buildDashboardServer({ rootOverride: tmp });
-    const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    expect(res.body).toContain('→ 한 번에 한 가지만');
+    const res = await app.inject({ method: 'GET', url: '/prompts?lang=en' });
+    expect(res.body).toContain('→ Output format not specified.');
     await app.close();
   });
 
-  it('does NOT render hint when a prompt has no rule hits', async () => {
+  it('does NOT render an arrow row when a prompt has no rule hits', async () => {
     const db = openDb();
     upsertSession(db, { id: 's-clean', cwd: '/tmp' });
     const u = insertPromptUsage(db, {
@@ -939,21 +948,11 @@ describe('Prompts list · inline hint (weak/bad KO)', () => {
       tier: 'good',
       rules_version: 1,
     });
-    // Note: intentionally NO insertRuleHit — the prompt passed every rule.
     db.close();
 
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    // Rows without any rule hit keep the snippet as a single line.
     expect(res.body).not.toContain('→');
-    await app.close();
-  });
-
-  it('skips hint for non-KO locales (examples are KO-only for now)', async () => {
-    await seedPromptWithHit('weak', 'R004');
-    const app = buildDashboardServer({ rootOverride: tmp });
-    const res = await app.inject({ method: 'GET', url: '/prompts?lang=en' });
-    expect(res.body).not.toContain('한 번에 한 가지만');
     await app.close();
   });
 });

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -885,11 +885,10 @@ describe('Prompts list · inline hints (full rule messages)', () => {
     return { id: u.id };
   }
 
-  it('renders only the highest-severity message plus a "+N more" badge', async () => {
-    // 3 hits → the row shows the top-severity message inline and a compact
-    // "+2 더" badge. The other two messages are NOT rendered inline (users
-    // click through to the detail page for the full list) — this keeps the
-    // table row height capped at two lines.
+  it('renders EVERY rule-hit message as its own "→ ..." line', async () => {
+    // 3 hits → all three messages appear inline, each on its own arrow
+    // line, in severity-DESC order. No "+N more" badge — users want the
+    // full catalogue visible on the list.
     await seedPromptWithHits('weak', [
       { rule_id: 'R002', severity: 3, message: '출력 형식이 지정되지 않았습니다.' },
       { rule_id: 'R006', severity: 2, message: '성공 기준이 없습니다.' },
@@ -898,42 +897,38 @@ describe('Prompts list · inline hints (full rule messages)', () => {
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
     expect(res.statusCode).toBe(200);
-    // Top message rendered verbatim.
     expect(res.body).toContain('→ 출력 형식이 지정되지 않았습니다.');
-    // Badge shows +2 더 (two additional hits beyond the first).
-    expect(res.body).toContain('+2 더');
-    // Lower-severity messages are NOT inlined on the list.
-    expect(res.body).not.toContain('→ 성공 기준이 없습니다.');
-    expect(res.body).not.toContain('→ 출력 제약(길이/언어/범위)이 없습니다.');
+    expect(res.body).toContain('→ 성공 기준이 없습니다.');
+    expect(res.body).toContain('→ 출력 제약(길이/언어/범위)이 없습니다.');
+    // No "more"-style counter lingering from earlier versions.
+    expect(res.body).not.toMatch(/\+\d+ 더/);
     await app.close();
   });
 
-  it('omits the badge when there is only one hit', async () => {
+  it('renders a single line with no counter for a single-hit row', async () => {
     await seedPromptWithHits('good', [
       { rule_id: 'R001', severity: 1, message: '프롬프트가 너무 짧습니다.' },
     ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
     expect(res.body).toContain('→ 프롬프트가 너무 짧습니다.');
-    // No badge counter when only 1 hit.
     expect(res.body).not.toMatch(/\+\d+ 더/);
     await app.close();
   });
 
-  it('picks the highest-severity message as the inline one', async () => {
-    // Seed with the lower-severity rule listed first to confirm ordering
-    // comes from the query (severity DESC, rule_id ASC), not insertion
-    // order.
+  it('orders rule-hit lines by severity DESC (high before low)', async () => {
+    // Seed the lower-severity hit first to confirm ordering comes from
+    // the query (severity DESC, rule_id ASC), not insertion order.
     await seedPromptWithHits('bad', [
       { rule_id: 'R001', severity: 1, message: 'LOW-SEVERITY-MARKER' },
       { rule_id: 'R004', severity: 4, message: 'HIGH-SEVERITY-MARKER' },
     ]);
     const app = buildDashboardServer({ rootOverride: tmp });
     const res = await app.inject({ method: 'GET', url: '/prompts?lang=ko' });
-    // HIGH-SEVERITY is the inline arrow, LOW-SEVERITY is absorbed into +1.
-    expect(res.body).toContain('→ HIGH-SEVERITY-MARKER');
-    expect(res.body).toContain('+1 더');
-    expect(res.body).not.toContain('→ LOW-SEVERITY-MARKER');
+    const hi = res.body.indexOf('→ HIGH-SEVERITY-MARKER');
+    const lo = res.body.indexOf('→ LOW-SEVERITY-MARKER');
+    expect(hi).toBeGreaterThan(-1);
+    expect(lo).toBeGreaterThan(hi);
     await app.close();
   });
 

--- a/packages/rules/src/rules.ts
+++ b/packages/rules/src/rules.ts
@@ -21,17 +21,17 @@ import {
 } from './keywords.js';
 import type { Rule } from './types.js';
 
-// R001 — too short
+// R001 — too short (D-046: severity 2 → 1, structural nudge, not punishment)
 export const r001: Rule = {
   id: 'R001',
   name: 'too_short',
   category: 'structure',
   description: 'Word count is extremely small, making intent hard to infer.',
-  severity: 2,
+  severity: 1,
   detect: ({ meta }) => {
     if (meta.wordCount >= 4) return null;
     return {
-      severity: 2,
+      severity: 1,
       message: '프롬프트가 너무 짧습니다. 목적·대상·기대 결과를 한 줄 더 추가해 보세요.',
       fixHint: 'expand_intent',
     };
@@ -74,7 +74,7 @@ export const r003: Rule = {
   },
 };
 
-// R004 — multiple tasks
+// R004 — multiple tasks (D-046: severity 3 → 4, genuine result pollution)
 // Covers two patterns:
 //   (a) conjunction-heavy: and/그리고/또한/plus appears 3+ times
 //   (b) explicit separators: `요약해줘 // 번역해줘 // 코드로` — 2+ `//` or `/` separators
@@ -84,7 +84,7 @@ export const r004: Rule = {
   name: 'multiple_tasks',
   category: 'structure',
   description: 'Multiple tasks joined with conjunctions or // separators.',
-  severity: 3,
+  severity: 4,
   detect: ({ promptText }) => {
     const lower = promptText.toLowerCase();
     const conjunctionPatterns = [/\band\b/gi, /그리고/gu, /또한/gu, /,\s*또/gu, /\bplus\b/gi];
@@ -121,7 +121,7 @@ export const r004: Rule = {
     if (separatorCount > 0) parts.push(`구분자(/ or //) ${separatorCount}회`);
     if (imperativeCount > 0) parts.push(`명령형 ${imperativeCount}회`);
     return {
-      severity: 3,
+      severity: 4,
       message: '여러 태스크가 섞여 있습니다. 하나씩 나누면 결과 품질이 올라갑니다.',
       evidence: parts.join(', '),
       fixHint: 'split_tasks',
@@ -223,44 +223,44 @@ export const r009: Rule = {
   },
 };
 
-// R010 — no output constraint
+// R010 — no output constraint (D-046: severity 2 → 1, structural nudge)
 export const r010: Rule = {
   id: 'R010',
   name: 'no_constraint',
   category: 'output',
   description: 'No output constraint (length/language/scope).',
-  severity: 2,
+  severity: 1,
   detect: ({ promptText, meta }) => {
     if (meta.wordCount < 15) return null;
     if (anyMatch(promptText, OUTPUT_CONSTRAINT_KEYWORDS)) return null;
     return {
-      severity: 2,
+      severity: 1,
       message: '출력 제약(길이/언어/범위)이 없습니다.',
       fixHint: 'add_output_constraint',
     };
   },
 };
 
-// R011 — question without context
+// R011 — question without context (D-046: severity 2 → 1, brevity not always a problem)
 export const r011: Rule = {
   id: 'R011',
   name: 'question_without_context',
   category: 'context',
   description: 'Short standalone question with no background.',
-  severity: 2,
+  severity: 1,
   detect: ({ promptText, meta }) => {
     if (meta.wordCount >= 15) return null;
     if (!anyMatch(promptText, QUESTION_MARKERS)) return null;
     if (anyMatch(promptText, CONTEXT_KEYWORDS)) return null;
     return {
-      severity: 2,
+      severity: 1,
       message: '배경 없이 단문 질문입니다. 이전에 무엇을 했는지 1줄 덧붙이면 좋습니다.',
       fixHint: 'add_background_to_question',
     };
   },
 };
 
-// R012 — code dump without instruction
+// R012 — code dump without instruction (D-046: severity 3 → 4, major result pollution)
 // Threshold lowered 0.8 → 0.65 after dogfooding surfaced the "300 lines of
 // code + one short question" pattern that slipped through at 0.8.
 export const r012: Rule = {
@@ -268,7 +268,7 @@ export const r012: Rule = {
   name: 'code_dump_no_instruction',
   category: 'structure',
   description: 'Prompt is mostly code (≥65%) with no clear instruction.',
-  severity: 3,
+  severity: 4,
   detect: ({ promptText }) => {
     const codeBlocks = promptText.match(/```[\s\S]*?```/g) ?? [];
     if (codeBlocks.length === 0) return null;
@@ -277,7 +277,7 @@ export const r012: Rule = {
     if (ratio < 0.65) return null;
     if (anyMatch(promptText, IMPERATIVE_KEYWORDS)) return null;
     return {
-      severity: 3,
+      severity: 4,
       message: '코드만 붙여넣으셨습니다. 원하는 동작(디버그/리뷰/설명)을 지시어로 추가하세요.',
       evidence: `코드 비율 ${(ratio * 100).toFixed(0)}%`,
       fixHint: 'add_code_action',

--- a/packages/worker/src/jobs.ts
+++ b/packages/worker/src/jobs.ts
@@ -1,14 +1,18 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import {
   composeFinalScore,
+  computeConfidence,
   computeUsageScore,
   createLogger,
   finishSubagent,
   llm,
+  loadBaseline,
   loadConfig,
   openDb,
+  refreshBaseline,
   transcript as tp,
   ulid,
+  updateUsageEfficiencyFeatures,
   upsertQualityScore,
 } from '@think-prompt/core';
 
@@ -117,9 +121,9 @@ export async function handleParseTranscript(
   // Compute usage scores per prompt_usage in this session
   const usages = ctx.db
     .prepare(
-      `SELECT id, prompt_hash FROM prompt_usages WHERE session_id = ? ORDER BY turn_index ASC`
+      `SELECT id, prompt_hash, turn_index FROM prompt_usages WHERE session_id = ? ORDER BY turn_index ASC`
     )
-    .all(payload.session_id) as Array<{ id: string; prompt_hash: string }>;
+    .all(payload.session_id) as Array<{ id: string; prompt_hash: string; turn_index: number }>;
 
   const totalCalls = toolSummary.reduce((a, b) => a + b.calls, 0);
   const rollup = ctx.db
@@ -130,7 +134,19 @@ export async function handleParseTranscript(
   const calls = rollup.calls ?? totalCalls;
   const fails = rollup.fails ?? 0;
 
-  for (const u of usages) {
+  // D-046 §3.4.1: extract per-turn efficiency features from the transcript.
+  // Zipped positionally against usages[] in their turn_index order. When the
+  // counts disagree (e.g. transcript clipped) we fall back to nulls for the
+  // overflow — the scorer treats missing efficiency as "not present" and
+  // renormalizes remaining weights.
+  const turnFeatures = tp.extractTurnEfficiency(events);
+
+  // Current baseline (may be null during cold-start).
+  const baseline = loadBaseline(ctx.db);
+
+  for (let i = 0; i < usages.length; i++) {
+    const u = usages[i]!;
+    const tf = turnFeatures[i];
     const hashSeenBefore = ctx.db
       .prepare(
         `SELECT COUNT(*) AS c FROM prompt_usages WHERE prompt_hash=? AND session_id=? AND id < ?`
@@ -144,6 +160,17 @@ export async function handleParseTranscript(
            FROM outcomes WHERE usage_id = ?`
       )
       .get(u.id) as { ups: number | null; downs: number | null };
+
+    // Persist per-turn efficiency features on prompt_usages so downstream
+    // re-scoring and dashboards can pick them up without reparsing.
+    if (tf) {
+      updateUsageEfficiencyFeatures(ctx.db, u.id, {
+        first_shot_success: tf.firstShotSuccess,
+        tool_call_count: tf.toolCalls,
+        follow_up_depth: tf.followUpDepth,
+      });
+    }
+
     const usageScore = computeUsageScore({
       toolCalls: calls,
       toolFails: fails,
@@ -151,16 +178,48 @@ export async function handleParseTranscript(
       responseLength: 0, // unknown per-usage without deeper correlation
       feedbackUps: fb.ups ?? 0,
       feedbackDowns: fb.downs ?? 0,
+      firstShotSuccess: tf?.firstShotSuccess ?? null,
+      turnToolCallCount: tf?.toolCalls ?? null,
+      followUpDepth: tf?.followUpDepth ?? null,
     });
+
     const existing = ctx.db
       .prepare(`SELECT rule_score, judge_score FROM quality_scores WHERE usage_id=?`)
       .get(u.id) as { rule_score: number; judge_score: number | null } | undefined;
     if (!existing) continue;
-    const { final_score, tier } = composeFinalScore({
+
+    // D-046: feed the asymmetric cap input (max severity + severity-3 count).
+    const sev = ctx.db
+      .prepare(
+        `SELECT COALESCE(MAX(severity),0) AS maxsev,
+                SUM(CASE WHEN severity=3 THEN 1 ELSE 0 END) AS sev3
+           FROM rule_hits WHERE usage_id=?`
+      )
+      .get(u.id) as { maxsev: number; sev3: number | null };
+
+    const {
+      final_score,
+      tier,
+      cap,
+      bonus: appliedBonus,
+    } = composeFinalScore({
       rule_score: existing.rule_score,
       usage_score: usageScore,
       judge_score: existing.judge_score ?? null,
+      maxSeverity: sev.maxsev,
+      severity3Count: sev.sev3 ?? 0,
     });
+
+    // D-046 §6 confidence. baseline_delta is null during cold-start — the
+    // computeConfidence helper treats null as "not a low-confidence signal".
+    const baselineDelta = baseline ? Math.round(final_score - baseline.avg_final_score) : null;
+    const confidence = computeConfidence({
+      maxSeverity: sev.maxsev,
+      hasUsageScore: usageScore != null,
+      hasJudgeScore: existing.judge_score != null,
+      baselineDelta,
+    });
+
     upsertQualityScore(ctx.db, {
       usage_id: u.id,
       rule_score: existing.rule_score,
@@ -169,8 +228,24 @@ export async function handleParseTranscript(
       final_score,
       tier,
       rules_version: 1,
+      efficiency_score: tf
+        ? Math.round(
+            (tf.firstShotSuccess ? 60 : 0) +
+              (tf.toolCalls <= 3 ? 27 : tf.toolCalls <= 8 ? 22 : 7) +
+              (tf.followUpDepth <= 1 ? 10 : tf.followUpDepth === 2 ? 7 : 4)
+          )
+        : null,
+      bonus_score: appliedBonus ?? 0,
+      cap_applied: cap ?? null,
+      confidence,
+      baseline_delta: baselineDelta,
     });
   }
+
+  // D-046 §5: refresh baseline snapshot once per transcript parse. Cheap
+  // (~one aggregate query) and keeps delta fresh without a separate cron.
+  refreshBaseline(ctx.db);
+
   ctx.logger.info(
     { session_id: payload.session_id, events: events.length, usages: usages.length },
     'session transcript parsed & rescored'
@@ -182,7 +257,10 @@ export async function handleSessionEnd(
   ctx: JobContext,
   payload: { session_id: string }
 ): Promise<'done' | 'retry'> {
-  // Enqueue judge jobs for low-scoring prompts in this session, if LLM enabled.
+  // Enqueue judge jobs for LOW-CONFIDENCE prompts in this session (D-046 §4.1).
+  // The old `final_score < threshold` trigger is kept as a fallback so scoring
+  // for pre-D-046 rows (where confidence is still NULL) still benefits from
+  // judge review.
   if (!ctx.config.llm.enabled) return 'done';
   const apiKey = process.env[ctx.config.llm.api_key_env];
   if (!apiKey) return 'done';
@@ -192,8 +270,8 @@ export async function handleSessionEnd(
          FROM quality_scores q
          JOIN prompt_usages u ON u.id = q.usage_id
         WHERE u.session_id = ?
-          AND q.final_score < ?
-          AND q.judge_score IS NULL`
+          AND q.judge_score IS NULL
+          AND (q.confidence = 'low' OR (q.confidence IS NULL AND q.final_score < ?))`
     )
     .all(payload.session_id, ctx.config.llm.judge_threshold_score) as Array<{ usage_id: string }>;
 


### PR DESCRIPTION
## 요약 / Summary

**D-006 (룰 70% + 실사용 30% · LLM 심판 `rule_score < 60`) supersede.**
D-006 의 선형 대칭 가중합은 "좋은 건 더 좋게, 나쁜 건 팍팍" 을 표현할 수 없고 시간/효율 축이 비어 있어 "짧아도 한 방에 풀린 프롬프트" 를 인정하지 못했다. D-046 은 스코어 출력을 `{score, tier, confidence, delta}` **4-tuple 계약**으로 바꾸고 다섯 축으로 재설계한다.

D-006's symmetric linear weighted sum could not express "good goes higher, bad drops harder" and had no time/efficiency axis. D-046 redefines the score output as a `{score, tier, confidence, delta}` **4-tuple contract** redesigned on five axes.

## 다섯 축 / Five axes

1. **Severity cap floor** — severity 4+ 히트 1개면 final 점수에 상한 강제 (≥5→40, ≥4→60, sev3×2→75). 다른 축이 100 이어도 덮지 못함.
2. **Positive bonus** — 감점 전용 탈피. 출력포맷·성공기준·예시·파일경로 신호로 최대 +10.
3. **Efficiency 축** — usage_score 에 first-shot success · tool call 경제성 · follow-up depth 추가. 짧은 성공 프롬프트가 정당하게 높은 점수.
4. **Personal baseline delta** — 누적 50턴 이후 유저 개인 rolling 평균 대비 delta 표시. 환경 변수(뉘앙스·맥락·기분) 자연 정규화.
5. **Confidence signaling** — high/medium/low. low 는 LLM judge 트리거 조건으로도 재바인딩 (기존 `rule_score < 60` 대체) → 비용 자연 감소.

## 주요 변경 / Key changes

- **Rules severity 재조정:** R001/R010/R011 2→1 (구조/스타일 완화), R004/R012 3→4 (실해 룰 강화), R005 유지(5)
- **Tier 밴드 상향:** good 85→90, ok 65→70, weak 45→50. good 진입에 positive bonus 사실상 필요
- **Schema (MIGRATION_006):** `quality_scores` 에 `efficiency_score`·`bonus_score`·`cap_applied`·`confidence`·`baseline_delta` 추가. `user_baseline_snapshots` 테이블 신규. `prompt_usages` 에 `first_shot_success`·`tool_call_count`·`follow_up_depth` 추가
- **Core:** `scorer.ts` 전면 재설계 (역호환 API 유지), 신규 모듈 `baseline.ts`·`confidence.ts`
- **Worker:** `handleParseTranscript` 가 transcript JSONL 파싱 시 efficiency 피처 추출 + 새 compose 호출 + baseline 자동 refresh. judge 트리거 `confidence='low'` 로 전환
- **Dashboard:** 디테일 hero 에 confidence 배지 + baseline delta + sub-score 확장 (eff/bonus/cap 노출). Overview 상단에 누적 턴 < 50 일 때 `calibrating… N/50` 배너로 콜드스타트 정직 표시
- **D-006 취소 섹션 이동**

## 테스트 플랜 / Test plan

- [x] `pnpm run ci` 그린 — build + typecheck + lint + test 전체 (261 tests passing, was 240)
- [x] 신규 테스트: `scorer.test.ts` 비대칭 cap + bonus + efficiency (22건), `baseline.test.ts` (7건), `confidence.test.ts` (6건)
- [x] 기존 테스트: `db.test.ts` schema version 6 으로 갱신, worker/dashboard/rules 테스트 전부 통과
- [ ] **로컬 dogfood (유저 확인)**: `pnpm -r build` → 격리 환경에서 `node packages/cli/dist/index.js install` → 몇 개 프롬프트 투입 → 대시보드에서 confidence/delta/calibrating 배너 육안 확인
- [ ] **DB migration 검증**: 기존 `~/.think-prompt/prompts.db` 로 재실행 시 MIGRATION_006 가 clean 하게 적용되는지

## 알려진 한계 / Known limits

- first-shot success 추정은 휴리스틱 (`/다시|아니|취소|재시도|redo|no wait|잘못|wrong|undo/i`). 유저 만족 vs 포기 구분에 오탐 가능 → 가중치 보수적으로 0.20 으로 시작. 1개월 데이터로 튜닝 예정
- baseline delta 는 누적 50턴 미만에선 `null` 반환 + UI `calibrating…` 배너
- 과거 데이터 재채점: 이 PR 에는 migration 만 포함, `think-prompt reprocess --all` 같은 일괄 재계산 명령은 후속

## 관계 / Relations

- **Supersedes D-006** (취소 섹션으로 이동)
- **D-032** (미션: 인지 고착 + 프롬프트 자각) 서피스를 구조적으로 강화 — "진짜 낮은 점수만 낮게, 잘 쓴 프롬프트는 후하게"
- **D-004** (로컬 중심) · **D-028** (fail-open) 와 정합. baseline·confidence·delta 모두 로컬 계산, LLM judge 호출 빈도 오히려 감소