### PR TITLE
release: v0.6.0 — JSON API에 D-046 4-tuple 필드 노출

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ _No unreleased changes._
 
 ---
 
+## [0.6.0] — 2026-05-12
+
+Embed-mode follow-up: the agent JSON API (added in D-047/0.5.0 carry) now
+surfaces D-046's 4-tuple fields so external dashboards (e.g. claude-alive)
+can render the same confidence / efficiency / baseline-delta signals the
+local dashboard already shows.
+
+### Added
+- **`/api/prompts`** and **`/api/prompts/:id`** now return three new
+  columns from `quality_scores`:
+  - `efficiency_score` — Phase 1 efficiency axis (`number | null`)
+  - `confidence` — D-046 confidence band (`'high' | 'medium' | 'low' | null`)
+  - `baseline_delta` — `final_score - user_baseline` once calibrated
+    (`number | null`)
+- **`/api/sessions/:id` prompt rows** also include `confidence` and
+  `baseline_delta` so list-style embeds can render a tier badge with the
+  same "참고용" / calibration hint the dashboard uses.
+- All response fields remain nullable and stay aligned with D-046's
+  philosophy: `confidence === 'low'` is a feature, not an error.
+
+### Unchanged
+- No schema migration — `MIGRATION_006` (0.5.0) already added these
+  columns. Older databases without those columns return `null`, which
+  embedders interpret as "calibrating…".
+- No new endpoints. No write paths touched. Hook contract unchanged.
+- D-004 (local-first) and D-028 (fail-open) still apply: only PII-masked
+  text is exposed, agent stays `127.0.0.1`-bound, JSON failures are caught.
+
+---
+
 ## [0.5.0] — 2026-04-24
 
 Two-stage learning loop release: **per-prompt inline hints** on the

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/agent",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Think-Prompt local HTTP hook receiver (127.0.0.1:47823)",
   "type": "module",
   "license": "MIT",

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -432,7 +432,8 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
       .prepare(
         `SELECT pu.id, pu.session_id, pu.pii_masked AS prompt, pu.char_len, pu.word_count,
                 pu.created_at, pu.turn_index,
-                qs.final_score, qs.rule_score, qs.usage_score, qs.tier
+                qs.final_score, qs.rule_score, qs.usage_score, qs.tier,
+                qs.efficiency_score, qs.confidence, qs.baseline_delta
          FROM prompt_usages pu
          LEFT JOIN quality_scores qs ON qs.usage_id = pu.id
          ${where}
@@ -451,6 +452,9 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
       rule_score: number | null;
       usage_score: number | null;
       tier: string | null;
+      efficiency_score: number | null;
+      confidence: string | null;
+      baseline_delta: number | null;
     }>;
     return { prompts: rows };
   });
@@ -462,7 +466,8 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
         `SELECT pu.id, pu.session_id, pu.pii_masked AS prompt, pu.char_len, pu.word_count,
                 pu.created_at, pu.turn_index, pu.coach_context,
                 qs.final_score, qs.rule_score, qs.usage_score, qs.judge_score, qs.tier,
-                qs.computed_at, qs.rules_version
+                qs.computed_at, qs.rules_version,
+                qs.efficiency_score, qs.confidence, qs.baseline_delta
          FROM prompt_usages pu
          LEFT JOIN quality_scores qs ON qs.usage_id = pu.id
          WHERE pu.id = ? OR pu.id LIKE ? || '%'
@@ -485,6 +490,9 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
           tier: string | null;
           computed_at: string | null;
           rules_version: number | null;
+          efficiency_score: number | null;
+          confidence: string | null;
+          baseline_delta: number | null;
         }
       | undefined;
     if (!row) {
@@ -560,7 +568,7 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
     const prompts = db
       .prepare(
         `SELECT pu.id, pu.pii_masked AS prompt, pu.created_at, pu.turn_index,
-                qs.final_score, qs.tier
+                qs.final_score, qs.tier, qs.confidence, qs.baseline_delta
          FROM prompt_usages pu
          LEFT JOIN quality_scores qs ON qs.usage_id = pu.id
          WHERE pu.session_id = ?
@@ -573,6 +581,8 @@ export function buildAgentServer(deps: AgentDeps = {}): FastifyInstance {
       turn_index: number;
       final_score: number | null;
       tier: string | null;
+      confidence: string | null;
+      baseline_delta: number | null;
     }>;
     return { session, prompts };
   });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "think-prompt",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Local-first prompt coach for Claude Code — collects your prompts via hooks, scores them with rules, and shows patterns in a private dashboard. No data leaves your machine.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Shared core: DB, types, logger, PII, scorer, transcript parser",
   "type": "module",
   "license": "MIT",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/dashboard",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Think-Prompt local web dashboard (127.0.0.1:47824) — 5-language i18n, deep analysis UI",
   "type": "module",
   "license": "MIT",

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/rules",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Think-Prompt antipattern rule catalog (R001..R018+) with positive/negative samples",
   "type": "module",
   "license": "MIT",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-prompt/worker",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Think-Prompt background worker: transcript parsing, LLM judge, rewriter",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
D-047 임베드 모드 follow-up. think-prompt agent의 JSON API에 D-046 4-tuple 계약(`{score, confidence, baseline_delta, ...}`)의 나머지 필드를 노출해서, claude-alive 같은 외부 임베드가 로컬 대시보드와 동일한 신호를 렌더할 수 있게 합니다.

스키마 변경 없음(MIGRATION_006이 0.5.0에서 이미 추가). 새 엔드포인트 없음. write path / hook 계약 / CORS / 바인드 정책 모두 무변.

## Changes
- `/api/prompts`, `/api/prompts/:id` 응답에 추가:
  - `efficiency_score: number | null`
  - `confidence: 'high' | 'medium' | 'low' | null`
  - `baseline_delta: number | null`
- `/api/sessions/:id` 의 prompt 행에 `confidence`, `baseline_delta` 포함
- CHANGELOG `[0.6.0]` 섹션 추가
- 워크스페이스 6개 패키지(core/rules/agent/worker/dashboard/cli) 모두 0.6.0으로 동기 bump

## 후속
- 머지 후 `git tag v0.6.0 && git push origin v0.6.0` → `.github/workflows/release.yml` 가 자동 npm publish (이 PR에서는 태그 푸시하지 않음 — 머지 확인 후 별도 작업)

## Test plan
- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과 (`lint:fix` 후 6개 자동 포맷)
- [ ] 머지 후 `git tag v0.6.0 && git push origin v0.6.0` → release workflow 성공 확인
- [ ] `npm view think-prompt versions` 에 `0.6.0` 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)