### PR TITLE
chore: archive notice — absorbed into claude-alive (D-048)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,179 +1,76 @@
-# Think-Prompt
+# think-prompt — absorbed into claude-alive
 
-> Claude Code에 **프롬프트 개인 코치**를 붙여주는 로컬-전용 오픈소스 도구.
-
-[![npm version](https://img.shields.io/npm/v/think-prompt.svg)](https://www.npmjs.com/package/think-prompt)
-[![npm downloads](https://img.shields.io/npm/dm/think-prompt.svg)](https://www.npmjs.com/package/think-prompt)
-[![CI](https://github.com/must-goldenrod/think-prompt/actions/workflows/ci.yml/badge.svg)](https://github.com/must-goldenrod/think-prompt/actions)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
-[![Release](https://img.shields.io/github/v/release/must-goldenrod/think-prompt)](https://github.com/must-goldenrod/think-prompt/releases)
+> 📦 **This repository is archived.** The think-prompt engine (agent, worker,
+> rules, core, CLI) has been folded into [**claude-alive**](https://github.com/must-goldenrod/claude-alive)
+> and is now developed there. The standalone `think-prompt` npm package is
+> deprecated.
 
 ---
 
-## 한 줄 요약
+## What happened
 
-여러분이 Claude Code에 **어떤 프롬프트를 어떻게 치는지** 로컬에 기록하고,
-**어디가 부족한지 조용히 알려주는** 무료 도구. 내 컴퓨터 밖으로 데이터가 나가지 않습니다.
+think-prompt and claude-alive shared the same user (a Claude Code developer)
+and lived next to each other on disk anyway. After the dashboard surface was
+rewritten in React inside claude-alive (the **Prompt** tab), the two
+projects no longer benefited from being separate repos. claude-alive
+absorbed think-prompt's packages on **2026-05-12** (D-048).
 
----
+| Old (think-prompt monorepo)        | New (claude-alive monorepo)           |
+|------------------------------------|----------------------------------------|
+| `packages/core` (`@think-prompt/core`)     | `packages/prompt-core`         |
+| `packages/rules` (`@think-prompt/rules`)   | `packages/prompt-rules`        |
+| `packages/agent` (`@think-prompt/agent`)   | `packages/prompt-agent`        |
+| `packages/worker` (`@think-prompt/worker`) | `packages/prompt-worker`       |
+| `packages/cli` (`think-prompt` binary)     | `packages/prompt-cli` (library only) |
+| `packages/dashboard` (`@think-prompt/dashboard`) | **dropped** — replaced by claude-alive React Prompt tab |
 
-## 🎯 이게 왜 필요한가요?
+Package names inside the workspace (`@think-prompt/core`, `@think-prompt/rules`,
+`@think-prompt/agent`, `@think-prompt/worker`) are unchanged so imports keep
+working. The user-facing CLI is now `claude-alive` (which orchestrates the
+absorbed engine internally).
 
-- "내가 짧게 대충 치면 Claude가 잘 못 답한다"는 걸 **숫자로** 확인하고 싶다.
-- 매번 **출력 형식 지정을 깜빡**한다. 누가 옆에서 리마인드해줬으면.
-- 지난주 내 프롬프트들 중 **뭐가 제일 구렸는지** 객관적으로 보고 싶다.
-- **프라이버시 걱정 없이** 프롬프트 로깅 도구를 쓰고 싶다.
+## Migration
 
----
+Existing installs continue to work — the SQLite database at
+`~/.think-prompt/prompts.db` and the agent at `127.0.0.1:47823` are
+preserved, including all collected prompts, scores, and rule hits.
 
-## 🚀 30초 설치
+To switch to the new combined product:
 
 ```bash
-# Node 20+ 필요
-npm i -g think-prompt
-think-prompt install                # 훅 + 데몬 자동 설정
-# Claude Code를 평소대로 쓰고
-think-prompt open                   # 대시보드 오픈 (http://127.0.0.1:47824)
+# (optional) Remove the deprecated standalone install:
+npm uninstall -g think-prompt
+
+# Install the absorbed product:
+npm install -g claude-alive
+claude-alive install   # registers hooks + starts agent + worker
+claude-alive start     # launches the dashboard at http://localhost:3141
 ```
 
-> 소스에서 빌드하려면 `git clone` → `pnpm install && pnpm -r build` → `node packages/cli/dist/index.js install`
+The `Prompt` tab inside the claude-alive dashboard renders the same data
+the old `127.0.0.1:47824` dashboard used to render, plus the D-046 4-tuple
+(confidence + baseline delta + efficiency).
 
-> 처음 써보시면 **[📘 완전 입문 가이드](./docs/GUIDE.md)** 부터. 터미널이 낯설어도 따라오실 수 있게 썼어요.
+## Why archive instead of unpublish
 
----
+npm packages with even one download are protected from unpublish to avoid
+breaking downstream consumers. Per npm download data, lifetime installs are
+just 248 (the vast majority concentrated on the original release day), but
+those installs still matter — they get a deprecation warning pointing to
+this notice instead of a hard 404.
 
-## ✨ 뭘 해주나요?
+## Historical artifacts
 
-### 1. 자동 수집
-Claude Code 훅으로 여러분이 친 모든 프롬프트·세션·서브에이전트 호출을 로컬 SQLite에 저장.
+- **Decision log** (`docs/00-decision-log.md`) — preserved here for the
+  D-001…D-047 entries that predate absorption. D-048 (the absorption
+  decision itself) lives in claude-alive's own decision log.
+- **CHANGELOG.md** — preserved here for the v0.1.0…v0.6.0 history.
+- **REPORT.md** / **CONTRIBUTING.md** / etc. — preserved for archaeological
+  purposes; design choices that survived absorption are now governed by
+  claude-alive's contribution guidelines.
 
-### 2. 품질 진단
-12개 안티패턴 룰로 0-100점 자동 채점.
-- R001 너무 짧음 · R002 출력 형식 미지정 · R003 맥락 없음
-- R004 한 프롬프트에 여러 태스크 · R005 프롬프트 인젝션 의심
-- ... (대시보드 `/rules` 에서 전체 목록)
+## Where to file issues
 
-### 3. 자동 리라이트 (선택)
-Anthropic API 키 있으면 낮은 점수 프롬프트를 Claude Haiku가 더 나은 버전으로 다시 씁니다. 원문은 여러분 PC에만, 리라이트 요청 시에만 마스킹본이 Anthropic에 갑니다.
+→ https://github.com/must-goldenrod/claude-alive/issues
 
-### 4. 로컬 대시보드
-`http://127.0.0.1:47824` — tier 분포, TOP 5 낮은 점수, 세션 타임라인, 룰 카탈로그.
-
-### 5. 인라인 코칭 (선택, 기본 OFF)
-`coach mode` ON 시 모호한 프롬프트에 Claude가 답하기 전에 **"확인 질문부터"** 하게 안내.
-
----
-
-## 🔒 프라이버시 약속
-
-- **원문 프롬프트는 여러분 PC 밖으로 나가지 않습니다.** (`D-004` 확정 결정)
-- 서버로 보내는 모드 없음 (v0.1 기준).
-- LLM 기능을 켰을 때만 마스킹된 사본이 Anthropic에 감 — Claude Code 자체가 이미 하는 일과 동일 범위.
-- PII (이메일·전화·주민번호·API 키·JWT 등)는 저장 전 자동 마스킹.
-- `think-prompt wipe --yes` 한 줄로 **모든 데이터 + 훅 완전 제거**.
-
-자세한 설계: [`docs/00-decision-log.md`](./docs/00-decision-log.md)
-
----
-
-## 🧰 CLI 명령어 (18개)
-
-```bash
-think-prompt install         # 훅 + 데몬 설치
-think-prompt uninstall       # 제거 (데이터 유지, --purge 로 완전 삭제)
-think-prompt start/stop/restart   # 데몬 제어
-think-prompt status          # 3개 데몬 상태
-think-prompt doctor          # 건강 진단 (훅 · 데몬 · DB · 로그)
-
-think-prompt list [--tier bad] [--rule R003] [--limit 20]
-think-prompt show <id>       # 프롬프트 상세 + 룰 히트 + 점수
-think-prompt rewrite <id> [--copy]   # LLM 리라이트 제안
-
-think-prompt coach on|off    # 인라인 코칭 토글
-think-prompt config get/set/list
-think-prompt reprocess [--all|--session <id>]
-
-think-prompt export --since 30d --out file.json
-think-prompt open            # 대시보드 브라우저 오픈
-think-prompt wipe --yes      # 완전 삭제
-```
-
----
-
-## 📁 프로젝트 구조
-
-```
-think-prompt/                        ← 리포 루트
-├── README.md                        ← 이 문서
-├── LICENSE                          ← MIT
-├── CHANGELOG.md                     ← 릴리스 노트
-├── CONTRIBUTING.md                  ← 기여 가이드
-├── docs/                            ← 설계 + 사용 문서
-│   ├── GUIDE.md                     ← 🌟 완전 입문 가이드
-│   ├── 00-decision-log.md           ← 모든 확정 결정(D-001..)
-│   ├── 01-hook-design.md            ← Claude Code 훅 설계
-│   ├── 02-tech-stack.md             ← 기술 스택
-│   ├── 03-local-storage.md          ← SQLite 스키마
-│   ├── 04-transcript-parser.md
-│   ├── 05-quality-engine.md         ← 룰 + 스코어 공식
-│   ├── 06-coaching-ux.md
-│   └── 07-build-and-test-plan.md    ← 마일스톤별 테스트 가이드
-└── packages/                        ← pnpm 워크스페이스 (6개)
-    ├── core/                        ← DB, 설정, 로거, PII, 스코어러
-    ├── rules/                       ← 안티패턴 룰 R001..R012
-    ├── agent/                       ← Fastify 훅 수신기 (:47823)
-    ├── worker/                      ← 백그라운드 작업 처리
-    ├── dashboard/                   ← 로컬 웹 UI (:47824)
-    └── cli/                         ← think-prompt 바이너리
-```
-
----
-
-## 📚 문서 지도
-
-| 상황 | 가세요 |
-|---|---|
-| 처음 써봐요 | [`docs/GUIDE.md`](./docs/GUIDE.md) — 초보자용 완전 가이드 |
-| 왜 이렇게 설계했는지 궁금 | [`docs/00-decision-log.md`](./docs/00-decision-log.md) |
-| 코드 기여할래요 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) |
-| 뭐가 바뀌었나요 | [`CHANGELOG.md`](./CHANGELOG.md) |
-| 빌드·테스트 방법 | [`docs/07-build-and-test-plan.md`](./docs/07-build-and-test-plan.md) |
-| 룰 추가하고 싶어요 | [`docs/05-quality-engine.md`](./docs/05-quality-engine.md) |
-
----
-
-## 🛠 개발
-
-```bash
-pnpm install           # 의존성
-pnpm -r build          # 전체 빌드
-pnpm typecheck         # 타입체크
-pnpm test              # 53개 테스트
-pnpm lint              # biome
-pnpm run ci            # 위 전부 순차 실행
-```
-
-CI는 Ubuntu + macOS × Node 20/22 매트릭스. Windows는 Phase 2.
-
----
-
-## 🗺️ 로드맵
-
-- **v0.1.x** — 버그 수정, 룰 튜닝, M0 실측 확정
-- **v0.2** — Cursor/VSCode 확장, 서버 동기화 (Opt-in)
-- **v0.3** — 팀 공유, 리뷰 워크플로
-- **v1.0** — Windows 지원, API 안정성 보증
-
-진행 중 이슈: https://github.com/must-goldenrod/think-prompt/issues
-
----
-
-## 📝 라이선스
-
-MIT. 자유롭게 쓰고 고치세요. PR 환영.
-
----
-
-## 🙏 기여자
-
-Made with ❤️ for the Claude Code community.
+The think-prompt issue tracker is disabled along with the repo archive.

--- a/docs/00-decision-log.md
+++ b/docs/00-decision-log.md
@@ -549,6 +549,36 @@
 
 ---
 
+## D-048 · claude-alive 로 흡수, 본 리포 archive
+
+- **Date:** 2026-05-12
+- **Context:** D-047 이후 claude-alive 의 React Prompt 탭이 자체 dashboard 패키지를 사실상 대체했다. 두 리포가 동일한 사용자(Claude Code 개발자) + 동일한 머신을 타겟으로 하면서 두 D-결정 로그·두 CHANGELOG·두 CI 를 유지하는 비용이 정당화되지 않음. npm 라이프타임 다운로드 248회 (출시일 외 일평균 1~2) 기준으로 외부 사용자 사실상 0 확인.
+- **Decision:** 5개 패키지(core, rules, agent, worker, cli)를 claude-alive 모노레포 `packages/prompt-{name}/` 으로 이전, dashboard 패키지는 폐기. think-prompt 리포는 archive (read-only) 처리. `think-prompt` npm 패키지는 deprecate ("absorbed into claude-alive" 메시지).
+- **Migration:**
+  - 모노레포 내부 import 경로 (`@think-prompt/core` 등)는 **그대로 유지** — claude-alive 안의 workspace 패키지 이름과 동일. 코드 import 0 변경.
+  - `packages/cli` 의 패키지명 `think-prompt` → `@think-prompt/cli-internal` (workspace-only). `bin` 필드 제거 — 사용자가 쓰는 CLI 는 이제 `claude-alive`.
+  - 사용자 데이터 (`~/.think-prompt/` SQLite + queue.jsonl) 경로 무변. 기존 설치자는 `claude-alive install` 후 그대로 데이터 호환.
+- **D-원칙 보존:**
+  - **D-028 fail-open** — agent 의 150ms 훅 예산·silent return 정책 그대로. claude-alive 의 CLI 가 throw 해도 agent/worker 는 분리된 데몬으로 계속 실행.
+  - **D-004 local-first** — 127.0.0.1 바인드 + PII 마스킹본만 노출. claude-alive UI 는 agent 의 JSON API 만 소비.
+  - **D-005 prompts vs prompt_usages 분리** — 스키마 무변.
+  - **D-012 (대시보드 번들러 없음)** — claude-alive UI 는 별도로 Vite + React 기반이라 이 결정은 dashboard 패키지와 함께 폐기. 새 stack 은 claude-alive 의 자체 D-결정으로 관리.
+- **Alternatives considered:**
+  - A. dashboard 패키지만 deprecate, 나머지 think-prompt 유지 — 두 리포 유지 비용 그대로. 반려.
+  - C. 전체 unpublish (npm 에서 패키지 제거) — npm 보호 정책상 72시간 지나 불가. 가능하더라도 248명 한 명이라도 보호.
+  - D. claude-alive 도 think-prompt 로 흡수 (역 방향) — 사용자가 보는 1st-class 표면이 시각화(claude-alive) 라 그 쪽이 brand. 반려.
+- **Scope:**
+  - 본 리포: README → archive 안내, `docs/00-decision-log.md` 에 D-048 추가, GitHub 측에서 archive flag on.
+  - claude-alive: PR #17 (5 패키지 이전 + dashboard role 제거 + claude-alive CLI 의 shell-out → workspace import 전환). 머지 완료.
+- **관계:** D-047(임베드 모드 + JSON API) — 이 결정이 D-048 의 전제. D-047 이후 dashboard 가 dispensable 해짐. D-038(dashboard 브랜드 정렬), D-039 / D-040 / D-043 / D-044(dashboard UX 결정들) — 모두 dashboard 패키지와 함께 effective scope 종료. 결정 자체는 보존 (역사적 기록).
+
+### 본 리포 상태
+- **GitHub:** archived (issues / PR 차단, 코드 read-only)
+- **npm:** `think-prompt@*` deprecated → "absorbed into claude-alive; install `claude-alive` instead"
+- **대체:** https://github.com/must-goldenrod/claude-alive
+
+---
+
 ## 취소된 결정
 
 ### D-006 · 품질 스코어 구성 (룰 70% + 실사용 30%, LLM 심판 `rule_score < 60`)


### PR DESCRIPTION
## Summary
5 패키지(core/rules/agent/worker/cli)가 [must-goldenrod/claude-alive#17](https://github.com/must-goldenrod/claude-alive/pull/17) 에서 claude-alive 모노레포로 이전되었습니다. dashboard 패키지는 React Prompt 탭으로 대체되어 폐기. 본 리포는 archive 처리하기 직전의 마지막 안내 커밋입니다.

## Changes
- **README** → archive / migration 안내로 전면 교체. 디렉토리 매핑 테이블, `claude-alive install` 마이그레이션 절차, "왜 unpublish 가 아닌 archive 인가" 설명 포함.
- **docs/00-decision-log.md** → D-048 추가:
  - 흡수 결정 + 라이프타임 다운로드 248 의 의사결정 근거
  - D-028 / D-004 / D-005 / D-012 가 어떻게 보존/폐기되는지 명시
  - alternatives (dashboard 만 deprecate / 전체 unpublish / 역방향 흡수) 평가
  - 본 리포 상태 (archive / npm deprecate / 대체 URL)
- **D-001~D-047 + CHANGELOG 모두 그대로 보존** — 역사 자료.

## 머지 후 (수동 작업)
사용자가 다음을 실행해야 archive 완료:

```bash
# 1. GitHub archive (issues / PR 동결, read-only)
gh api -X PATCH repos/must-goldenrod/think-prompt -F archived=true

# 2. npm deprecate (NPM_TOKEN 갱신 후)
npm deprecate think-prompt "absorbed into claude-alive; install \`claude-alive\` instead"
```

## Test plan
- [x] README 텍스트만 변경 — 빌드 영향 없음
- [x] decision-log 텍스트만 변경
- [ ] 머지 후 GitHub archive flag 설정
- [ ] npm deprecate 명령 실행 (npm 토큰 갱신 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)